### PR TITLE
docs: problem-first README rewrite + workflow diagram (en + zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,107 @@ This is the **public** companion to Stometa's private `stometa-skillset`. We dog
 
 The first batch ships two skills: `review-loop` (already proven in daily use) and `harness` (multi-agent orchestration for larger tasks). Both are installable as a single Claude Code plugin.
 
+## Workflow at a glance
+
+`harness` is a cybernetics-inspired orchestrator: planning and execution live in **separate sessions** so context cannot leak; every checkpoint runs against a **fresh sub-agent** to reset eigenbehavior; an **engine script** owns state and enforces hard gates so the LLM cannot self-certify; and a **cross-model peer** (a different vendor's CLI) reviews before PR so you never merge on a single model's opinion. Persistent retro feeds learnings back into future tasks — that's the closing loop of the cybernetic system.
+
+```mermaid
+flowchart TB
+    H((Human))
+    H -->|"harness plan task-id"| HOST
+
+    subgraph HOST["Orchestrator host — pick one (symmetric)"]
+        direction LR
+        CC["Claude Code CLI"]
+        CX["Codex CLI"]
+    end
+
+    HOST --> ENG[["harness-engine.sh<br/>single source of truth<br/>state · phase machine · hard gates"]]
+
+    ENG --> S1
+    subgraph S1["Session 1 — Planning (recommended host: Claude Code)"]
+        direction TB
+        PL["Orchestrator = Planner<br/>brainstorm + draft spec.md"]
+        SE["harness-spec-evaluator<br/>fresh sub-agent (Claude)"]
+        OK1["spec.md approved"]
+        PL --> SE
+        SE -->|revise| PL
+        SE -->|approve| OK1
+    end
+
+    S1 -. session ends — planning context discarded .-> S2
+
+    subgraph S2["Session 2 — Execution (recommended host: Codex)"]
+        direction TB
+        CPL{{"For each Checkpoint NN"}}
+        GEN["harness-generator<br/>fresh sub-agent per CP<br/>TDD + verification preloaded"]
+        EVL{"harness-evaluator<br/>fresh sub-agent per CP<br/>Tier 1 deterministic + Tier 2 LLM"}
+        MORE{"more checkpoints?"}
+        E2E["E2E Evaluator<br/>cross-checkpoint data-flow audit"]
+        RL[["review-loop<br/>cross-model quality gate"]]
+        FV["full-verify<br/>tests · coverage ≥ threshold · lint · types"]
+        PR["Open PR"]
+        RT["harness-retro<br/>fresh sub-agent"]
+
+        CPL --> GEN --> EVL
+        EVL -->|FAIL / REVIEW| GEN
+        EVL -->|PASS| MORE
+        MORE -->|yes| CPL
+        MORE -->|no| E2E
+        E2E -->|FAIL| GEN
+        E2E -->|PASS| RL
+        RL --> FV --> PR --> RT
+    end
+
+    subgraph RLSUB["review-loop · cross-LLM peer review"]
+        direction LR
+        PEER["Peer reviewer CLI<br/>codex OR gemini<br/>(allowlisted)"]
+        HEV["Host LLM evaluates<br/>ACCEPT / REJECT / INSIST"]
+        FRESH["Fresh peer session<br/>final approval pass"]
+        DONE["pass-review-loop"]
+
+        PEER -->|FINDING fN| HEV
+        HEV -->|fix + commit| PEER
+        PEER -.CONSENSUS.-> FRESH --> DONE
+    end
+    RL -. invokes .-> RLSUB
+
+    RT --> RD[(".harness/retro/<br/>cross-task learnings<br/>git-tracked, persistent")]
+    RD -. informs future tasks .-> H
+
+    classDef antiDrift stroke:#d97706,stroke-width:2px;
+    class GEN,EVL,SE,RT antiDrift;
+    classDef gate stroke:#059669,stroke-width:2px;
+    class ENG,RL,FV gate;
+```
+
+**Legend** — orange-bordered nodes are the **fresh-sub-agent** drift firewalls; green-bordered nodes are the **engine-enforced gates** that the LLM cannot bypass.
+
+### Hosts and roles
+
+The model running each role is decoupled from the model hosting the session — that's why the same pipeline works whether you start in Claude Code or Codex.
+
+| Role | Who plays it | Notes |
+|---|---|---|
+| **Orchestrator host** (Session 1 + 2) | Claude Code CLI **or** Codex CLI | Symmetric. Recommended split: Claude Code for Session 1, Codex for Session 2. |
+| **Spec Evaluator** | Claude (sub-agent or via `claude-agent-invoke.sh`) | Stable across hosts. |
+| **Generator** | Active host LLM (Claude or Codex) | Inherits the host. |
+| **Evaluator / E2E / Retro** | Claude (sub-agent or via `claude-agent-invoke.sh`) | Engine rejects same-context self-evaluation. |
+| **`review-loop` peer** (cross-model gate) | `codex` CLI **or** `gemini` CLI — allowlisted | Claude is **not** a peer here by design — same-vendor review would defeat the cross-model purpose. |
+
+> Heads-up on the peer allowlist: the bundled `review-loop` skill enforces `peer ∈ {codex, gemini}` in preflight. If Claude is hosting, the peer is naturally a different vendor; if Codex is hosting, picking `codex` still gives you a fresh isolated context (different `CODEX_HOME`, no MCP, stripped credentials), and `gemini` gives you a true cross-vendor read.
+
+## What makes Harness different
+
+| Concern | Typical multi-agent loop | This Harness skill |
+|---|---|---|
+| **Context drift** | One growing context across plan → code → review | Two-session split + fresh sub-agent per checkpoint (eigenbehavior reset) |
+| **Self-certification** | LLM judges its own output | `harness-engine.sh` blocks `pass-checkpoint` until the latest `evaluation.md` has `verdict: PASS` **and** the evaluator session id was not reused by any prior checkpoint |
+| **Echo-chamber review** | Same model reviews itself | `review-loop` enforces a different-vendor peer (Codex or Gemini) and runs a **fresh-session final approval pass** so the closing verdict isn't biased by the iterative repair conversation |
+| **Black-box state** | State implicit in chat history | All state on disk (`.harness/<task-id>/`, `git-state.json`), one engine script owns the phase machine, every transition is auditable |
+| **No memory across tasks** | Each task starts cold | Persistent `.harness/retro/` (git-tracked) accumulates error patterns, rule proposals, and skill defects — closes the cybernetic feedback loop |
+| **Tool-use bias** | Lock-in to one CLI / one vendor | Orchestrator host and review peer are independently swappable; the same engine and gates run on Claude Code or Codex |
+
 ## Skills
 
 ### `review-loop`
@@ -46,7 +147,9 @@ claude plugin list | grep harness-engineering-skills
 
 ## Usage
 
-**review-loop** — inside a Claude Code session, once the plugin is installed:
+### `review-loop` (standalone)
+
+Inside a Claude Code session, once the plugin is installed:
 
 ```
 /review-loop
@@ -54,13 +157,36 @@ claude plugin list | grep harness-engineering-skills
 
 Variants: `review loop with gemini`, `review loop, max 3 rounds`, `review loop for PR 42`, `review loop for commit abc123`.
 
-**harness** — start a new orchestrated task:
+The peer reviewer is one of `codex` or `gemini` — set globally via `.review-loop/config.json` (`peer_reviewer`), or per-invocation. The loop iterates until peer and host reach `CONSENSUS`, then runs a fresh-session final approval pass before writing `summary.md`.
+
+### `harness` (orchestrated task)
+
+Two recommended entry patterns — both produce the identical pipeline shown in the diagram above:
+
+**Pattern A — Claude Code drives planning, Codex drives execution (recommended):**
+
+```
+# Session 1, in Claude Code
+harness plan <task-id>          # interactive spec creation + spec review
+
+# Session 2, in Codex (fresh process, planning context discarded by design)
+harness execute <task-id>       # checkpoints → E2E → review-loop → full-verify → PR → retro
+```
+
+**Pattern B — single host (Claude Code or Codex) for everything:**
 
 ```
 harness plan <task-id>
+harness continue                # same host runs both phases
 ```
 
-Then follow the planning dialogue; `harness` will drive checkpoints through Generator → Evaluator with a cross-model review gate before producing a PR.
+Pick the cross-model peer once in `.harness/config.json`:
+
+```json
+{ "cross_model_review": true, "cross_model_peer": "gemini" }
+```
+
+`harness` will not let `pass-checkpoint`, `pass-e2e`, `pass-review-loop`, or `pass-full-verify` succeed unless the corresponding artifacts exist with the right verdict — the engine is the gatekeeper, not the LLM.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,107 @@ Stometa 对外公开的 Claude Code 精选技能集 —— 一套我们自己每
 
 第一批发布两个技能：`review-loop`（日常已经在用）和 `harness`（面向复杂任务的多智能体编排）。两者作为同一个 Claude Code 插件安装。
 
+## 工作流总览
+
+`harness` 是一套受控制论（cybernetics）启发的编排器：**规划与执行被强制拆到两个会话**，上下文不会串味；**每个 checkpoint 都用全新的子智能体**重置 eigenbehavior；一个**引擎脚本**独占状态并强制硬闸门，LLM 无法自我盖章；产 PR 之前必须经过一次**跨模型同行评审**（不同厂商的 CLI），不会基于单模型意见就合入。每次任务的复盘会持久化下来反哺后续任务 —— 这就是这套控制论系统的闭环。
+
+```mermaid
+flowchart TB
+    H((Human))
+    H -->|"harness plan task-id"| HOST
+
+    subgraph HOST["Orchestrator host — pick one (symmetric)"]
+        direction LR
+        CC["Claude Code CLI"]
+        CX["Codex CLI"]
+    end
+
+    HOST --> ENG[["harness-engine.sh<br/>single source of truth<br/>state · phase machine · hard gates"]]
+
+    ENG --> S1
+    subgraph S1["Session 1 — Planning (recommended host: Claude Code)"]
+        direction TB
+        PL["Orchestrator = Planner<br/>brainstorm + draft spec.md"]
+        SE["harness-spec-evaluator<br/>fresh sub-agent (Claude)"]
+        OK1["spec.md approved"]
+        PL --> SE
+        SE -->|revise| PL
+        SE -->|approve| OK1
+    end
+
+    S1 -. session ends — planning context discarded .-> S2
+
+    subgraph S2["Session 2 — Execution (recommended host: Codex)"]
+        direction TB
+        CPL{{"For each Checkpoint NN"}}
+        GEN["harness-generator<br/>fresh sub-agent per CP<br/>TDD + verification preloaded"]
+        EVL{"harness-evaluator<br/>fresh sub-agent per CP<br/>Tier 1 deterministic + Tier 2 LLM"}
+        MORE{"more checkpoints?"}
+        E2E["E2E Evaluator<br/>cross-checkpoint data-flow audit"]
+        RL[["review-loop<br/>cross-model quality gate"]]
+        FV["full-verify<br/>tests · coverage ≥ threshold · lint · types"]
+        PR["Open PR"]
+        RT["harness-retro<br/>fresh sub-agent"]
+
+        CPL --> GEN --> EVL
+        EVL -->|FAIL / REVIEW| GEN
+        EVL -->|PASS| MORE
+        MORE -->|yes| CPL
+        MORE -->|no| E2E
+        E2E -->|FAIL| GEN
+        E2E -->|PASS| RL
+        RL --> FV --> PR --> RT
+    end
+
+    subgraph RLSUB["review-loop · cross-LLM peer review"]
+        direction LR
+        PEER["Peer reviewer CLI<br/>codex OR gemini<br/>(allowlisted)"]
+        HEV["Host LLM evaluates<br/>ACCEPT / REJECT / INSIST"]
+        FRESH["Fresh peer session<br/>final approval pass"]
+        DONE["pass-review-loop"]
+
+        PEER -->|FINDING fN| HEV
+        HEV -->|fix + commit| PEER
+        PEER -.CONSENSUS.-> FRESH --> DONE
+    end
+    RL -. invokes .-> RLSUB
+
+    RT --> RD[(".harness/retro/<br/>cross-task learnings<br/>git-tracked, persistent")]
+    RD -. informs future tasks .-> H
+
+    classDef antiDrift stroke:#d97706,stroke-width:2px;
+    class GEN,EVL,SE,RT antiDrift;
+    classDef gate stroke:#059669,stroke-width:2px;
+    class ENG,RL,FV gate;
+```
+
+**图例** —— 橙色描边的节点是**全新子智能体**形成的"防漂移防火墙"；绿色描边的节点是 LLM 无法绕开的**引擎硬闸门**。
+
+### 角色与宿主对照
+
+每个角色由谁来扮演，与会话宿主是哪个 LLM 解耦 —— 这正是同一套流水线在 Claude Code 起手和在 Codex 起手都能跑通的原因。
+
+| 角色 | 由谁扮演 | 说明 |
+|---|---|---|
+| **编排宿主**（Session 1 + 2） | Claude Code CLI **或** Codex CLI | 对称可换。推荐拆法：Session 1 用 Claude Code，Session 2 用 Codex。 |
+| **Spec Evaluator** | Claude（子智能体或通过 `claude-agent-invoke.sh`） | 跨宿主稳定不变。 |
+| **Generator** | 当前宿主 LLM（Claude 或 Codex） | 跟随宿主。 |
+| **Evaluator / E2E / Retro** | Claude（子智能体或通过 `claude-agent-invoke.sh`） | 引擎拒绝同上下文自评。 |
+| **`review-loop` peer**（跨模型闸门） | `codex` CLI **或** `gemini` CLI —— 白名单限定 | Claude **不**作为这里的 peer，这是有意为之 —— 同厂商互评违背"跨模型"初衷。 |
+
+> 关于 peer 白名单的提醒：`review-loop` 在 preflight 阶段强制 `peer ∈ {codex, gemini}`。如果宿主是 Claude，peer 自然是另一家厂商；如果宿主是 Codex，选 `codex` 也能拿到一个全新隔离的上下文（独立 `CODEX_HOME`、关闭 MCP、剥离凭证），选 `gemini` 则是真正的跨厂商交叉读。
+
+## 这套 Harness 与常见多智能体方案的差异
+
+| 关注点 | 常见多智能体回路 | 本仓库的 Harness |
+|---|---|---|
+| **上下文漂移** | 规划 → 编码 → 评审共用一个不断膨胀的上下文 | 双会话拆分 + 每个 checkpoint 全新子智能体（eigenbehavior 重置） |
+| **自我盖章** | LLM 给自己产出的代码下结论 | `harness-engine.sh` 在最新 `evaluation.md` 不是 `verdict: PASS`、且 evaluator session id 与历史 checkpoint 重复时，直接拒绝 `pass-checkpoint` |
+| **回音壁式评审** | 同模型自评自审 | `review-loop` 强制 peer 来自不同厂商（Codex 或 Gemini），并在最终通过前用**全新会话**做一次终审，避免被迭代修复中的对话偏置 |
+| **黑盒状态** | 状态隐式藏在聊天上下文里 | 全部状态落盘（`.harness/<task-id>/`、`git-state.json`），单一引擎脚本掌管阶段机，每次状态迁移都可审计 |
+| **任务间无记忆** | 每个任务从零开始 | 持久化的 `.harness/retro/`（纳入 git）累积错误模式、规则提案、技能缺陷 —— 闭合控制论反馈环 |
+| **工具锁定** | 强绑定单一 CLI / 单一厂商 | 编排宿主和评审 peer 各自可换；同一套引擎和闸门在 Claude Code 与 Codex 上都能跑 |
+
 ## 技能清单
 
 ### `review-loop`
@@ -46,7 +147,9 @@ claude plugin list | grep harness-engineering-skills
 
 ## 使用
 
-**review-loop** —— 在 Claude Code 会话中（插件已安装后）：
+### `review-loop`（独立使用）
+
+插件安装好后，在 Claude Code 会话里：
 
 ```
 /review-loop
@@ -54,13 +157,36 @@ claude plugin list | grep harness-engineering-skills
 
 变体：`review loop with gemini`、`review loop, max 3 rounds`、`review loop for PR 42`、`review loop for commit abc123`。
 
-**harness** —— 启动一个新的编排任务：
+Peer 评审者只能是 `codex` 或 `gemini` —— 通过 `.review-loop/config.json` 中的 `peer_reviewer` 全局配置，或在调用时按需覆盖。回路会持续迭代直到 peer 与宿主达成 `CONSENSUS`，再用一个全新会话做终审，最后才写入 `summary.md`。
+
+### `harness`（编排任务）
+
+两种推荐入口 —— 都对应上方流程图里同一条流水线：
+
+**模式 A —— Claude Code 负责规划，Codex 负责执行（推荐）：**
+
+```
+# Session 1，在 Claude Code 中
+harness plan <task-id>          # 交互式产出 spec 并完成 spec 评审
+
+# Session 2，在 Codex 中（全新进程，规划上下文按设计被丢弃）
+harness execute <task-id>       # checkpoints → E2E → review-loop → full-verify → PR → retro
+```
+
+**模式 B —— 单一宿主（Claude Code 或 Codex）跑完整流程：**
 
 ```
 harness plan <task-id>
+harness continue                # 同一宿主跑完两个阶段
 ```
 
-按规划对话进行后，`harness` 会驱动各个 checkpoint 在 Generator 和 Evaluator 之间推进，并在产出 PR 之前先经过一次跨模型审查闸门。
+跨模型 peer 在 `.harness/config.json` 里一次性指定：
+
+```json
+{ "cross_model_review": true, "cross_model_peer": "gemini" }
+```
+
+只要对应产物缺失或裁决不是 PASS，`harness` 就不会让 `pass-checkpoint`、`pass-e2e`、`pass-review-loop`、`pass-full-verify` 通过 —— 守门人是引擎，不是 LLM。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

Two-commit README revamp turning the README into a problem-first pitch backed by a visual workflow.

**Commit 1 — workflow diagram + supporting tables**
- A single Mermaid flowchart covering the full Harness pipeline: dual entry hosts (Claude Code / Codex) → engine → Session 1 (Plan + Spec Eval) → Session 2 (Generator ↔ Evaluator per checkpoint → E2E → review-loop → full-verify → PR → Retro) → persistent retro feedback into future tasks. `classDef` styling separates fresh-sub-agent drift firewalls from engine-enforced gates.
- "Hosts and roles" table decoupling session host from role player; surfaces the `{codex, gemini}` peer allowlist.
- "What makes Harness different" comparison vs typical multi-agent loops across six concerns.
- Expanded Usage with Pattern A (split host) and Pattern B (single host).

**Commit 2 — problem-first hero rewrite**
- New hero tagline: *"Let an AI agent code for hours unattended — and ship PRs you'd actually merge."*
- "The pain you've probably felt" — five concrete failure modes (drift, fake PASS, echo-chamber review, no cross-task memory, babysitting) so readers self-identify in seconds.
- "What Harness actually does" — five mechanisms that close those failure modes one-for-one, plus a note on the bundled `phase-guard` hook.
- "What's in the box" — component table (2 skills + 4 sub-agents + engine + hook + scripts) so the surface area is inspectable at a glance.
- Drops the now-duplicate standalone "Skills" section; folds the legend into the diagram lead-in.

**Out of band (already applied):**
- GitHub About description rewritten to lead with the autonomous-for-hours hook.
- 6 new discovery topics added: `autonomous-agents`, `ai-agents`, `llm-agents`, `multi-agent`, `agent-framework`, `orchestration`.

No code or skill behavior changes — docs and repo metadata only.

## Test plan

- [ ] Mermaid diagram renders correctly on GitHub for `README.md`
- [ ] Mermaid diagram renders correctly on GitHub for `README.zh-CN.md`
- [ ] EN ↔ ZH language toggle links at the top of each README still work
- [ ] No broken markdown (tables, code fences, blockquotes, ordered lists)
- [ ] Hero blockquote, tables, and ordered lists all render cleanly
- [ ] Updated About description visible on the repo landing page
- [ ] New topics show up in the topic chip list