### PR TITLE
merge: consolidate harness (v0.13.0) and review-loop (v1.3.0) from stometa-skillset

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -64,6 +64,78 @@ For each checkpoint evaluate:
 3. **Scaling concerns** — anything that would become a bottleneck at 10x load?
 4. **Security surface** — auth, data access, API boundaries adequately addressed?
 
+### Phase 5: Validation Claim Audit (always do last, before writing verdict)
+
+Empirical claims asserted without evidence are the worst kind of spec poison:
+they look authoritative but pre-commit the Generator to a choice no one has
+actually verified. Phase 5 is a mechanical scan, not a judgment call — run
+it on every spec review.
+
+**1. Scan the entire spec body** (Goal, Success Criteria, Technical Approach,
+Checkpoint descriptions, Out of Scope — everything except the YAML
+frontmatter) for these phrase patterns, case-insensitive:
+
+- `validated via`
+- `tested via`
+- `verified against`
+- `benchmarked at`
+- `measured at`
+- `reverse-engineered`
+
+Standalone tool names (`curl`, `psql`, `jq`, etc.) are **explicitly excluded**
+from the scan. They routinely appear in execution-guidance prose ("Generator
+should run `curl …`") and matching them would produce a storm of false
+positives that trains reviewers to ignore the gate.
+
+**2. For each match, check adjacency for inline evidence.** A well-supported
+claim MUST have, directly adjacent (same paragraph or the immediately
+following fenced block):
+
+- The exact `command` that was run, with any secrets/tokens/hostnames sanitized
+  to `REDACTED` or dummy values.
+- An `output snippet` proving the claim. Default cap is **≤ 20 lines**. The
+  spec author may override this with an HTML comment marker on its own line
+  **immediately before** the snippet: `<!-- evidence-limit: N -->`, where
+  `N ≤ 100`. Markers with `N > 100`, or markers placed anywhere other than
+  immediately before the snippet, do **not** raise the cap — treat the claim
+  as unsupported.
+- An **ISO-8601 capture date** (e.g. `2026-04-15` or `2026-04-15T14:32:10Z`)
+  so a reader can tell when the evidence was gathered.
+
+**3. Classify each match:**
+
+- **Missing any of the three elements above** → emit a concern with
+  `severity: critical` whose text explicitly quotes the claim phrase (so the
+  Planner can locate it mechanically). This forces `verdict: revise` — do
+  **not** approve a spec with unsupported empirical claims, even if every
+  other phase is clean.
+- **Match sits inside execution-guidance context** — i.e. the surrounding
+  prose is instructing the Generator to run the command later, not asserting
+  that someone has already run it (phrases like "Generator should run",
+  "the implementation will be tested via", "before merging, validate via") —
+  downgrade to `severity: info`. This avoids critical blocks on forward-looking
+  instructions that are not evidence claims at all.
+- **All three elements present and within the applicable line limit** →
+  no concern emitted for this match.
+
+**4. Record the audit outcome in the output** regardless of result:
+
+- If zero matches were found: note `Validation Claim Audit: 0 matches scanned,
+  clean.` in the Concerns section preamble so the Planner sees the gate ran.
+- If matches were found: list each as a numbered concern with severity,
+  quoted claim phrase, file location (section + nearby line marker), and a
+  suggested_fix that tells the Planner either "attach inline evidence per
+  protocol-quick-ref.md#Evidence Requirements" or "rephrase to make the
+  execution-guidance intent unambiguous".
+
+**Boundary rules — Phase 5 MUST NOT:**
+
+- Modify the spec itself (that is the Planner's job).
+- Attempt to verify whether the claim is *true* — Phase 5 audits presence and
+  shape of evidence, not correctness.
+- Suppress a match merely because it "seems reasonable" or "the author is
+  trusted". The rule is mechanical on purpose: authority is not evidence.
+
 ## Output
 
 Write `round-N-spec-review.md` in the spec-review/ directory per protocol format:
@@ -99,6 +171,9 @@ For each checkpoint:
 - Critical = blocks execution, must fix before approve
 - Warning = should fix, but won't block if justified
 - Info = suggestion for improvement
+- Begin this section with a one-line Phase 5 audit summary
+  (e.g. `Validation Claim Audit: 0 matches scanned, clean.` or
+  `Validation Claim Audit: 2 matches, 1 critical / 0 warning / 1 info.`).
 
 **Effort Estimate:** S/M/L per checkpoint
 

--- a/plugins/harness-engineering-skills/skills/harness/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/harness/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: harness
-version: 0.11.0
+version: 0.13.0
 description: |
   Cybernetics-based multi-agent orchestration for complex tasks. Coordinates a
   Planner → Generator → Evaluator → Retro pipeline with clean-context sub-agents,
   per-checkpoint drift prevention, and persistent retro learning.
 
   Recommended workflow: Claude Code plans the spec (Session 1), Codex executes
-  autonomously (Session 2), Gemini reviews as cross-model peer via `review-loop`.
+  autonomously (Session 2), Claude CLI reviews as cross-model peer.
 
   Use when: "harness this task", "use harness", "orchestrate this",
   "harness plan", "harness continue", "harness execute <task-id>",
@@ -22,14 +22,14 @@ Fresh sub-agents per checkpoint prevent drift. Retro accumulates learning across
 ## Recommended Workflow
 
 ```
-Session 1 (Claude Code) → Plan + Spec → Spec review with cross-model evaluator
+Session 1 (Claude Code) → Brainstorm + Spec → Spec review with cross-model evaluator
     ↓ spec approved
 Session 2 (Codex)       → Execute checkpoints → Evaluate → E2E → Full-verify → PR → Retro
-    ↕ Gemini CLI as review-loop peer (cross-model quality gate)
+    ↕ Claude CLI as review-loop peer (cross-model quality gate)
 ```
 
-- **Session 1**: Claude Code for interactive discovery — brainstorming, multi-turn Q&A, spec refinement with Spec Evaluator.
-- **Session 2**: Codex for autonomous execution — implementation, evaluation, PR creation, retro. A second peer CLI (Codex or Gemini, matching the `review-loop` skill's supported peers) serves as cross-model reviewer via `review-loop`.
+- **Session 1**: Claude Code for interactive discovery — brainstorming + multi-turn Q&A to establish requirements. **After the user approves the brainstormed design, spec drafting and the Spec Evaluator review loop run autonomously** (agent-to-agent until consensus). See [references/planning-protocol.md](references/planning-protocol.md) "Post-Brainstorming Autonomy".
+- **Session 2**: Codex for autonomous execution — implementation, evaluation, PR creation, retro. Claude CLI serves as cross-model reviewer via `review-loop`.
 - Both hosts support both phases. The above is the **recommended** flow, not a hard constraint.
 
 ## Prerequisites
@@ -38,7 +38,7 @@ Session 2 (Codex)       → Execute checkpoints → Evaluate → E2E → Full-ve
 2. Reviewer role definitions: `harness-spec-evaluator.md`, `harness-generator.md`, `harness-evaluator.md`, `harness-retro.md` — ship with this plugin at `plugins/harness-engineering-skills/agents/`; user overrides may live at `~/.claude/agents/harness-*.md`
 3. `python3` on PATH (engine JSON operations)
 4. `git` repository initialized
-5. For Codex-hosted execution: `claude` CLI on PATH for sub-agent dispatch (reviewer roles). The `review-loop` peer is a separate choice (`codex` or `gemini`) — see the `review-loop` skill.
+5. For Codex-hosted execution: `claude` CLI on PATH for sub-agent dispatch and review-loop
 
 Verify (Claude Code): `claude plugin list | grep superpowers`
 Verify (review roles): `ls ~/.claude/plugins/**/plugins/harness-engineering-skills/agents/harness-*.md 2>/dev/null || ls plugins/harness-engineering-skills/agents/harness-*.md` (plugin-bundled) and `ls ~/.claude/agents/harness-*.md 2>/dev/null` (optional user override)
@@ -63,7 +63,8 @@ Delegate ALL file-system and git bookkeeping to the engine.
 | `max_spec_rounds` | `3` | 1–5 |
 | `max_eval_rounds` | `3` | 1–5 |
 | `cross_model_review` | `true` | `true` → triggers `review-loop` after E2E, before PR |
-| `cross_model_peer` | `codex` | `codex`, `gemini` — matches the peers supported by the bundled `review-loop` skill |
+| `cross_model_peer` | `codex` | `codex`, `claude`, `gemini` — use `claude` when Codex is the host |
+| `cross_model_read_only` | `false` | `true` = report-only, `false` = iterative fix |
 | `auto_retro` | `true` | `false` to skip retro |
 | `claude_md_path` | `auto` | Path to CLAUDE.md. `auto` detects |
 | `max_verify_rounds` | `3` | 1–5, max iterations for full-verify fix loop |

--- a/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
@@ -7,7 +7,7 @@ Use this reference when Codex is the orchestrator. The pipeline (Planning → Ch
 - Codex acts as the Orchestrator and local implementer (Generator role within checkpoints).
 - `harness-engine.sh` remains the single source of truth for task state, checkpoints, and phase gates — same engine, same commands, same phase machine.
 - Sub-agent roles (Spec Evaluator, Evaluator, Retro) are dispatched via `claude-agent-invoke.sh` to a Claude CLI process. Any CLI that accepts a prompt and returns structured output can fill these roles.
-- `review-loop` uses a peer reviewer configured via its own skill (`codex` or `gemini`) — the choice is a config option, not an architectural constraint.
+- `review-loop` can use any available peer (`codex`, `claude`, or `gemini`) — the choice is a config option, not an architectural constraint.
 
 > **Symmetry**: The role assignments are interchangeable. Just as Codex can host with Claude sub-agents, Claude Code can host with Codex as the review-loop peer. This document covers the Codex-as-host configuration.
 
@@ -36,8 +36,10 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
 
 1. Clarify requirements directly with the user.
    - If a dedicated brainstorming skill is unavailable in Codex, do the questioning and design synthesis manually.
-2. Write `.harness/<task-id>/spec.md` in the normal Harness format.
-3. For each spec-review round, invoke Claude as the spec reviewer:
+2. Write `.harness/<task-id>/spec.md` in the normal Harness format. **After this step,
+   the remainder of planning is autonomous** — see the "Post-Brainstorming Autonomy"
+   section in [planning-protocol.md](planning-protocol.md).
+3. For each spec-review round, invoke Claude as the spec reviewer (fresh each round):
 
 ```bash
 "$CLAUDE_AGENT" \
@@ -46,7 +48,16 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
   --output-file ".harness/$TASK_ID/spec-review/round-${ROUND}-spec-review.md"
 ```
 
-4. Apply accepted spec changes locally in Codex, then repeat until approved.
+4. Apply accepted spec changes locally in Codex and write `round-N-planner-response.md`
+   documenting accepted/rejected concerns with rationale. Repeat autonomously until
+   `approve` verdict or `max_spec_rounds` is exhausted. Escalate to the user only
+   in the scenarios enumerated in `planning-protocol.md`'s `Post-Brainstorming
+   Autonomy` exhaustive list (max_spec_rounds exhaustion, critical-contradicts-design,
+   or critical-acceptance-infeasible).
+   - Rejecting a warning-severity concern requires a `Verification:` block in the
+     Rejected Changes entry (see [protocol-quick-ref.md#verification-block](protocol-quick-ref.md#verification-block)).
+     Critical concerns cannot be rejected — escalate per the
+     `Post-Brainstorming Autonomy` rules in [planning-protocol.md](planning-protocol.md).
 
 ## Execution in Codex
 
@@ -78,13 +89,16 @@ For each checkpoint:
 
 ## Cross-Model Review
 
-After E2E passes, `review-loop` provides the cross-model quality gate. Set `cross_model_peer` in `.harness/config.json` (or pass `--cross-model-peer <name>` to the engine) to pick a peer supported by the bundled `review-loop` skill:
+After E2E passes, `review-loop` provides the cross-model quality gate. Configure it with any available peer:
 
-- `cross_model_peer=codex` — a second Codex instance reviews (fresh context in a clean process)
-- `cross_model_peer=gemini` — Gemini reviews (true cross-model when Codex hosts)
+- `peer_reviewer=claude` — Claude reviews Codex's implementation
+- `peer_reviewer=codex` — a second Codex instance reviews (same-model, still useful for fresh context)
+- `peer_reviewer=gemini` — Gemini reviews
 
-`review-loop` always runs as an iterative fix loop (peer finds issues, host fixes, iterate to consensus). There is no read-only mode in the bundled skill.
+Options:
+- `read_only=false` — normal fix loop (peer finds issues, host fixes, iterate)
+- `read_only=true` — report-only (collect signal without code changes)
 
-`pass-review-loop` treats `.review-loop/latest/rounds.json` as a completion contract: `session.status` must be `consensus`, and `session.total_rounds` must be at least 1.
+`pass-review-loop` now treats `.review-loop/latest/rounds.json` as a completion contract: `session.status` must be `consensus` or `read_only_complete`, and `session.total_rounds` must be at least 1.
 
 This is the same review-loop step that the Claude Code-hosted path runs. The peer choice is orthogonal to who hosts.

--- a/plugins/harness-engineering-skills/skills/harness/references/execution-protocol.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/execution-protocol.md
@@ -1,6 +1,6 @@
 # Execution Protocol (Session 2)
 
-**Recommended host**: Codex — autonomous execution, with a different peer CLI (`codex` or `gemini`) supplied to the bundled `review-loop` skill as the cross-model reviewer.
+**Recommended host**: Codex — autonomous execution, Claude CLI as cross-model reviewer.
 
 **Sub-agent dispatch**: In Claude Code use `Agent(subagent_type: "harness-*", ...)`. In Codex, the host implements locally (Generator role) and dispatches review-heavy roles via `claude-agent-invoke.sh`. See [codex-mode.md](codex-mode.md) for Codex-specific details.
 
@@ -148,13 +148,13 @@ One match → load. Multiple → ask user. None → inform user.
 5. Cross-model review (ENFORCED by engine phase gate — execute automatically, do NOT ask user):
    → If cross_model_review=true (default):
      → Directly invoke `review-loop` with scope: branch (no confirmation needed)
-     → Select a peer that differs from the host (e.g. cross_model_peer=gemini when Codex hosts)
-     → review-loop always iterates to consensus (no read-only mode in the bundled skill)
+     → When Codex is the host, set cross_model_peer=claude for true cross-model review
+     → Default mode: read_only=false (peer finds issues, host fixes, iterate to consensus)
      → review-loop produces .review-loop/<session>/summary.md + rounds.json
      → If review-loop finds critical issues → fix and re-run E2E (step 4)
      → $ENGINE pass-review-loop --task-id <id>
        (engine verifies .review-loop/latest/summary.md + rounds.json exist,
-        session.status is consensus, and session.total_rounds >= 1)
+        session.status is consensus/read_only_complete, and session.total_rounds >= 1)
    → If cross_model_review=false:
      → $ENGINE skip-review-loop --task-id <id>
        (engine verifies config flag before allowing skip)
@@ -316,8 +316,8 @@ When Generator encounters conflicting rules:
 | Dependency | Used By | Purpose |
 |-----------|---------|---------|
 | `superpowers` plugin | Generator, Orchestrator | TDD (preloaded), verification-before-completion, systematic-debugging, brainstorming in Claude Code |
-| bundled `review-loop` skill | Orchestrator | Cross-model peer review step (supports peers: codex, gemini) |
-| `claude` CLI | Codex-hosted Orchestrator | Sub-agent role dispatch for Spec Evaluator / Evaluator / Retro (not a `review-loop` peer — review-loop supports codex and gemini) |
+| `sto` plugin (this skill) | Orchestrator | `review-loop` in Claude Code |
+| `claude` CLI | Codex-hosted Orchestrator | Sub-agent roles + optional `review-loop --peer claude` |
 
 **Optional (enhanced capabilities):**
 

--- a/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
@@ -20,6 +20,35 @@ When `superpowers:brainstorming` is invoked within the Harness pipeline, the Har
 
 After brainstorming produces an approved design, **return to step 3** below.
 
+## Post-Brainstorming Autonomy (steps 3–7)
+
+Once the user approves the brainstormed design in step 2, the remainder of the planning
+pipeline is **fully autonomous**. Spec drafting, Spec Evaluator review, and the review
+iteration run agent-to-agent until consensus.
+
+### NEVER pause to ask the user between steps 3 and 7 about:
+- Whether to proceed from brainstorm → spec draft (just draft it)
+- Whether to spawn the Spec Evaluator (just spawn it)
+- Whether to start the next spec-review round (just run it)
+- Which Spec Evaluator concerns to accept/reject — apply judgment autonomously per
+  severity (see step 5 below)
+- "Ready for review?" / "Should I continue?" / mid-flow status confirmations
+
+### The ONLY scenarios requiring human input after brainstorming (exhaustive list):
+1. **`max_spec_rounds` exhausted without an `approve` verdict** — surface the final
+   spec + unresolved concerns to the user.
+2. Critical Spec Evaluator concern actually contradicts the brainstormed design — escalate to user; do not reject autonomously.
+   (Warning-level concerns that contradict the brainstormed design are NOT an
+   escalation trigger — they are handled autonomously per step 5's warning rule
+   by attaching a `Verification:` block to the rejection.)
+3. **Autonomous acceptance of a `critical` concern is infeasible** — step 5's
+   critical rule says "ALWAYS accept" but if the revision cannot be performed
+   within one round without breaking the brainstormed design, escalate rather
+   than silently defer.
+
+Everything else is autonomous. Record any remaining ambiguities in the spec's
+`Open Questions` section rather than pausing to ask.
+
 ## Planning Flow
 
 ```
@@ -32,19 +61,35 @@ After brainstorming produces an approved design, **return to step 3** below.
    → STOP when user approves the design
    → Do NOT proceed to brainstorming's "Write design doc" / "Invoke writing-plans" steps
 
-3. Produce spec.md → write to .harness/<task-id>/spec.md
+3. Produce spec.md → write to .harness/<task-id>/spec.md  (AUTONOMOUS — no user pause)
    → Convert the approved design into Harness spec format (see protocol-quick-ref.md)
    → Include checkpoints with ### Checkpoint NN: <title> format
    → Set status: draft in YAML frontmatter
 
-4. Spawn Spec Evaluator sub-agent for spec review:
-   → Agent(subagent_type: "harness-spec-evaluator", prompt: <spec + codebase context + protocol-quick-ref.md>)
+4. Spawn Spec Evaluator sub-agent for spec review  (AUTONOMOUS — no user pause):
+   → Agent(subagent_type: "harness-spec-evaluator", prompt: <spec + codebase context + protocol-quick-ref.md + prior deferred rejections>)
+   → **Prior deferred rejections input** (rounds ≥ 2): include the prior
+     `round-(N-1)-planner-response.md`'s Rejected Changes entries whose
+     Verification: block is Form B (authority-only). Ask the Evaluator to
+     decide, for each, whether to re-raise the concern in this round or accept
+     the deferral. This is the executable path for the Form B deferral rule
+     documented in `protocol-quick-ref.md §verification-block`.
    → Spec Evaluator writes round-N-spec-review.md (format in protocol-quick-ref.md)
    → Reviews: checkpoint quality, acceptance criteria testability, feasibility, failure modes
 
-5. Iterate spec-review (max max_spec_rounds, then escalate to user)
+5. Iterate spec-review autonomously (max max_spec_rounds):
    → Fresh Spec Evaluator per round (not SendMessage) — each round reviews different spec version
-   → Planner writes round-N-planner-response.md documenting accepted/rejected changes
+   → Planner applies judgment AUTONOMOUSLY to each concern (no user pause):
+     - critical severity → ALWAYS accept; cannot be rejected under the "contradicts brainstormed design" clause. Escalate to user if autonomous acceptance is infeasible.
+     - warning severity → accept unless it contradicts the brainstormed design.
+       Rejecting a warning concern requires a `Verification:` block in round-N-planner-response.md (format defined in protocol-quick-ref.md §verification-block).
+     - info severity → accept if cheap; otherwise note in planner-response.md
+   → Write round-N-planner-response.md documenting accepted/rejected changes
+   → Loop continues until `approve` verdict or max_spec_rounds reached
+   → Escalate to user in any of the three scenarios listed under "The ONLY
+     scenarios requiring human input after brainstorming" above (max_spec_rounds
+     exhaustion OR critical-contradicts-design OR autonomous acceptance of a
+     critical concern is infeasible)
 
 6. Mark spec status: approved
 

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -30,6 +30,141 @@ Sections: Goal, Success Criteria, Checkpoints, Technical Approach, Out of Scope,
 ```
 Each checkpoint MUST use `### Checkpoint NN: <title>` heading (zero-padded number). The engine uses this exact pattern for `assemble-context` extraction.
 
+### Evidence Requirements (enforced by Spec Evaluator Phase 5)
+
+Whenever the spec asserts that a decision, threshold, design, or value was
+validated empirically, the claim MUST carry **inline sanitized evidence**.
+This applies to any of the following phrase patterns appearing in the spec
+body (Goal / Success Criteria / Technical Approach / Checkpoint descriptions):
+
+- `validated via`
+- `tested via`
+- `verified against`
+- `benchmarked at`
+- `measured at`
+- `reverse-engineered`
+
+Standalone tool names (`curl`, `psql`, etc.) are intentionally **not** scanned —
+they frequently appear in execution-guidance prose (e.g. "Generator should run
+`curl ...`") and would produce false positives.
+
+**Required inline shape** — directly adjacent to the claim:
+
+1. The exact `command` that was run (sanitize: replace secrets/tokens/hostnames
+   with `REDACTED` or dummy values).
+2. An `output snippet` proving the claim — **≤ 20 lines by default**.
+3. An **ISO-8601 capture date** (e.g. `2026-04-15` or `2026-04-15T14:32:10Z`)
+   so a reader can tell when the evidence was gathered.
+
+**Overriding the line limit** — when a longer snippet is genuinely necessary
+(e.g. a benchmark table), place an HTML comment marker on its own line
+**immediately before** the snippet:
+
+```markdown
+<!-- evidence-limit: 60 -->
+```
+
+- `N` MUST be `≤ 100`. Values above 100 are rejected by Phase 5 as noise that
+  belongs in a separate evidence file, not inline in the spec.
+- The marker applies only to the immediately following snippet; the default
+  20-line cap resumes for subsequent claims.
+
+**Enforcement** — The Spec Evaluator's Phase 5 "Validation Claim Audit" scans
+for the phrase patterns above. Any match lacking command + output snippet
+(within the applicable line limit) + ISO-8601 date is emitted as a
+`severity: critical` concern causing verdict `revise`. Matches appearing in
+clearly execution-guidance context (e.g. "Generator should run `curl …`") are
+downgraded to `severity: info`.
+
+---
+
+## verification-block
+
+The canonical **Verification: block** format is a shared evidence artifact used
+wherever a reviewer, peer agent, or checkpoint artifact must back a rejection
+or warning with empirical proof. It is referenced by:
+
+- `round-N-planner-response.md` Rejected Changes entries — each warning-level
+  rejection attaches a Verification: block.
+- `review-loop` rejection entries — the `claude_actions[].verification` field
+  (see `log-schema.md` for the `deferred for verification` auto-downgrade
+  behavior).
+- Any future artifact adopting the Evidence over Authority principle.
+
+**Two valid forms** — every Verification: block MUST be exactly one of:
+
+### Form A — Evidence-based (preferred)
+
+```yaml
+Verification:
+  command: <exact command run, sanitized — secrets/tokens/hostnames
+            replaced with REDACTED or dummy values>
+  output: |
+    <≤ 20-line snippet of stdout/stderr proving the claim>
+  timestamp: <ISO-8601, e.g. 2026-04-17 or 2026-04-17T14:32:10Z>
+  contradiction-explanation: <one or two sentences explaining HOW the
+                              output contradicts the peer's finding>
+```
+
+All four fields (`command`, `output`, `timestamp`, `contradiction-explanation`)
+are REQUIRED in Form A.
+
+### Form B — Verification-impossible
+
+```yaml
+Verification:
+  reason: <why verification could not be performed — e.g. "no network in
+           sandbox", "external API requires auth we don't hold",
+           "behavior only reproduces under production load">
+```
+
+Using Form B is an admission that the rejection rests on authority (spec /
+design / convention) without empirical proof. Consumers of the block MUST
+auto-downgrade such rejections to `deferred for verification` status:
+
+- In `review-loop`, the finding is NOT counted as `rejected` in `rounds.json`
+  (it goes to the `deferred for verification` bucket per
+  `log-schema.md#claude_actionsaction`) and is surfaced in `summary.md`'s
+  "Deferred for Verification" section when `summary.deferred_for_verification > 0`.
+- In spec-review `round-N-planner-response.md`, a warning rejection carrying
+  Form B is authority-only: the rejection is recorded as deferred (rather than
+  closed) and SHOULD be re-surfaced in the next round by passing the prior
+  planner-response.md to the Spec Evaluator (see `planning-protocol.md` step 4's
+  "Prior deferred rejections" input). Re-insisted Form B deferrals remain
+  autonomous — the Planner should attach Form A evidence in the current round
+  if possible, otherwise continue deferring. Unresolved deferrals ride the
+  normal `max_spec_rounds`-exhaustion path to user escalation (scenario 1 in
+  the exhaustive list); warning-level concerns never trigger a separate user
+  escalation.
+
+### Output snippet limit
+
+The `output` field in Form A MUST be ≤ 20 lines by default. When a longer
+snippet is genuinely necessary (e.g. a benchmark table, a multi-step repro),
+place an HTML comment marker on its own line **immediately before** the block:
+
+```markdown
+<!-- evidence-limit: 60 -->
+Verification:
+  command: ...
+  output: |
+    ... up to 60 lines ...
+```
+
+- `N` MUST be `≤ 100`. Values above 100 are rejected as noise that belongs in
+  a separate evidence file rather than inline in the artifact.
+- The marker applies only to the immediately following block; the default
+  20-line cap resumes afterward.
+
+This convention matches the spec.md Evidence Requirements §Overriding the
+line limit — keep the two consistent.
+
+### Timestamp format
+
+ISO-8601, either date-only (`YYYY-MM-DD`) or date-time with timezone
+(`YYYY-MM-DDTHH:MM:SSZ` or `±HH:MM` offset). Locale-dependent formats
+(`04/17/2026`, `Apr 17 2026`) are rejected.
+
 ---
 
 ## round-N-spec-review.md (spec-review/)
@@ -63,6 +198,8 @@ round: <N>
 ```
 
 Sections: Accepted Changes, Rejected Changes, Spec Updated To (version).
+
+Rejected Changes entries for warnings MUST include a Verification: block per §verification-block.
 
 ---
 
@@ -263,7 +400,7 @@ Sections:
 **Phase commands:**
 - `pass-checkpoint` — requires latest iteration `output-summary.md`, latest iteration `evaluation.md`, `evaluation.md` verdict PASS, and fresh `evaluator-session-id.txt`; then records final SHA.
 - `pass-e2e` — requires latest `e2e/iter-N/e2e-report.md` verdict PASS; then records final SHA and sets phase to `e2e`.
-- `pass-review-loop` — verifies `.review-loop/latest/summary.md` + `rounds.json` exist, `session.status` is `consensus`, and `session.total_rounds >= 1`; then records the session id and sets phase to `review-loop`
+- `pass-review-loop` — verifies `.review-loop/latest/summary.md` + `rounds.json` exist, `session.status` is `consensus` or `read_only_complete`, and `session.total_rounds >= 1`; then records the session id and sets phase to `review-loop`
 - `skip-review-loop` — only allowed when `cross_model_review=false` in config, sets phase to `review-loop`
 - `begin-full-verify` — requires phase `review-loop`, sets phase to `full-verify`, creates `full-verify/` directory
 - `pass-full-verify` — requires `full-verify/iter-N/verification-report.md` with verdict PASS or PASS_WITH_WARNINGS, rejects stale artifacts, records final SHA

--- a/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# harness-engine.sh — Deterministic state machine for sto:harness orchestration.
+# harness-engine.sh — Deterministic state machine for harness orchestration.
 # Handles directory creation, git-state.json, SHA recording, gitignore, state
 # transition validation, context assembly, and abort/rollback.
 #
@@ -1105,9 +1105,9 @@ print(data.get('session', {}).get('id', ''))
 
   local normalized_status
   normalized_status=$(echo "$rl_status" | tr '[:upper:]' '[:lower:]')
-  if [[ "$normalized_status" != "consensus" ]]; then
+  if [[ "$normalized_status" != "consensus" && "$normalized_status" != "read_only_complete" ]]; then
     echo "PHASE_BLOCKED" >&2
-    echo "REASON=review-loop session ${rl_session:-unknown} status is ${rl_status}; expected consensus" >&2
+    echo "REASON=review-loop session ${rl_session:-unknown} status is ${rl_status}; expected consensus or read_only_complete" >&2
     echo "NEXT_STEP=Resolve review-loop findings until consensus, or escalate if the session ended without consensus" >&2
     exit 1
   fi

--- a/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
@@ -1,28 +1,30 @@
 ---
 name: review-loop
-version: 1.0.0
+version: 1.3.0
 description: |
-  Cross-LLM iterative code review loop. Spawns a peer reviewer (Codex or Gemini CLI)
+  Cross-LLM iterative code review loop. Spawns a peer reviewer (Codex, Claude, or Gemini CLI)
   to review code changes, then iterates until both agents agree on the final code state.
   Code gets modified during the loop — the final output is improved code + consensus report.
 
   Use when: "review loop", "peer review", "cross review", "review with codex",
-  "review with gemini", "让 codex review", "交叉 review", "peer review 这段代码",
-  "code review loop", "iterative review"
+  "review with claude", "review with gemini", "让 codex review", "让 claude review",
+  "交叉 review", "peer review 这段代码", "code review loop", "iterative review"
 ---
 
 # Review Loop — Cross-LLM Iterative Code Review
 
-Spawns a peer reviewer (Codex or Gemini) to independently review your code changes.
-Claude evaluates findings, implements accepted fixes, and re-submits for peer re-review.
+Spawns a peer reviewer (Codex, Claude, or Gemini) to independently review your code changes.
+The host agent evaluates findings, implements accepted fixes, and re-submits for peer re-review.
 Iterates until both agents agree on the final code state.
 
 **Key**: You (the human) do NOT need to participate. Watch progress via `.review-loop/<session>/rounds.json` and `summary.md`.
 
+**Compatibility note**: `rounds.json` keeps the historical field name `claude_actions` for backward compatibility. In Codex-hosted runs, that field still stores the host agent's decisions and code changes.
+
 ## Prerequisites
 
 - **Required**: `git` CLI
-- **Peer (one of)**: `codex` CLI (`codex --version`) or `gemini` CLI (`gemini --version`)
+- **Peer (one of)**: `codex` CLI (`codex --version`), `claude` CLI (`claude --version`), or `gemini` CLI (`gemini --version`)
 - **Optional**: `gh` CLI (for PR scope detection)
 
 ## Configuration
@@ -31,12 +33,15 @@ Iterates until both agents agree on the final code state.
 
 | Setting | Default | Options |
 |---------|---------|---------|
-| `peer_reviewer` | `codex` | `codex`, `gemini` |
+| `peer_reviewer` | `codex` | `codex`, `claude`, `gemini` |
 | `max_rounds` | `5` | 1–10 |
 | `timeout_per_round` | `600` | seconds |
 | `scope_preference` | `auto` | `auto`, `diff`, `branch`, `pr` |
+| `read_only` | `false` | `true` = report-only, no code changes |
 
-The peer reviewer always runs with full local repository access and the loop always implements accepted fixes. There is no read-only mode.
+The peer reviewer always runs with local repository access.
+
+**Read-only mode** (`read_only: true`): Peer reviews code and the host agent evaluates findings, but NO code changes are made. Output is a findings report only — no fix commits, no code evolution loop. Useful when review-loop is used as a **sensor** by other skills (e.g., the bundled `harness` skill's Evaluator Tier 2). In read-only mode, Phase 2 (Code Evolution Loop) is skipped entirely — after Round 1 findings are evaluated, the loop goes directly to Phase 3 report generation with all findings classified as `reported` (not `accepted`/`rejected`).
 
 ### Override via project config
 
@@ -61,17 +66,21 @@ Invocation overrides take highest precedence.
 **IMPORTANT**: Run `preflight.sh` in a SINGLE bash call. This eliminates ~15 sequential tool calls.
 
 ```bash
-# Locate the skill's scripts directory (works for plugin installs and local clones)
-SKILL_DIR=""
-for candidate in \
-  "$(find ~/.claude/plugins/cache -path "*/review-loop/scripts/preflight.sh" 2>/dev/null | head -1 | xargs dirname 2>/dev/null | xargs dirname 2>/dev/null)" \
-  "$(find ~/.claude/skills -path "*/review-loop/scripts/preflight.sh" 2>/dev/null | head -1 | xargs dirname 2>/dev/null | xargs dirname 2>/dev/null)"; do
-  [[ -d "$candidate" ]] && SKILL_DIR="$candidate" && break
-done
+SKILL_DIR="${SKILL_BASE_DIR:-}"
+if [[ -z "$SKILL_DIR" || ! -x "$SKILL_DIR/scripts/preflight.sh" ]]; then
+  for candidate in \
+    "$(find ~/.claude/plugins/cache -path "*/review-loop" -type d 2>/dev/null | head -1)" \
+    "$(find ~/.claude/skills -path "*/review-loop" -type d 2>/dev/null | head -1)" \
+    "$(find ~/.codex/skills -path "*/review-loop" -type d 2>/dev/null | head -1)"; do
+    [[ -x "$candidate/scripts/preflight.sh" ]] && SKILL_DIR="$candidate" && break
+  done
+fi
+
 if [[ -z "$SKILL_DIR" ]]; then
-  echo "Error: review-loop skill directory not found. Ensure the plugin is installed." >&2
+  echo "Error: review-loop skill directory not found" >&2
   exit 1
 fi
+
 PREFLIGHT_OUTPUT="$($SKILL_DIR/scripts/preflight.sh \
   --peer {peer_reviewer} \
   --max-rounds {max_rounds} \
@@ -143,7 +152,8 @@ PEER_SCRIPT=""
 for candidate in \
   "$SKILL_BASE_DIR/scripts/peer-invoke.sh" \
   "$(find ~/.claude/plugins/cache -path "*/review-loop/scripts/peer-invoke.sh" 2>/dev/null | head -1)" \
-  "$(find ~/.claude/skills -path "*/review-loop/scripts/peer-invoke.sh" 2>/dev/null | head -1)"; do
+  "$(find ~/.claude/skills -path "*/review-loop/scripts/peer-invoke.sh" 2>/dev/null | head -1)" \
+  "$(find ~/.codex/skills -path "*/review-loop/scripts/peer-invoke.sh" 2>/dev/null | head -1)"; do
   [[ -x "$candidate" ]] && PEER_SCRIPT="$candidate" && break
 done
 
@@ -155,7 +165,7 @@ fi
 
 > **Note**: `$SKILL_BASE_DIR` is set by Claude Code from the skill's metadata. The fallback searches the plugin cache and skills directories.
 
-`peer-invoke.sh` runs Codex in the current repository directory with full access so it can read local files directly. For Codex, it also launches against an isolated temporary `CODEX_HOME` with no MCP servers, strips inherited `CODEX_API_KEY` by default, and records the peer session id for reuse in later rounds.
+`peer-invoke.sh` runs the selected peer in the current repository directory so it can read local files directly. For Codex, it also launches against an isolated temporary `CODEX_HOME` with no MCP servers, strips inherited `CODEX_API_KEY` by default, and records the peer session id for reuse in later rounds. For Claude, it uses JSON output mode and records the Claude session id for reuse.
 
 Invoke:
 ```bash
@@ -175,11 +185,13 @@ Read `round-1-raw.txt`. Parse for:
 
 ### Step 1.5: Update rounds.json
 
-Add Round 1 data with all `peer_findings`. Set `claude_actions` to empty (not yet evaluated).
+Add Round 1 data with all `peer_findings`. Set `claude_actions` to empty (historical field name; stores host-side actions).
 
 ---
 
 ## Phase 2: Code Evolution Loop
+
+**If `read_only: true`**: Skip this entire phase. Go directly to Phase 3 with all Round 1 findings classified as `reported` (not accepted/rejected). No code changes, no checkpoint commits, no re-review rounds.
 
 For each round N (starting from Round 1's findings):
 
@@ -188,9 +200,9 @@ For each round N (starting from Round 1's findings):
 For each peer finding, apply the evaluation criteria from [synthesis-protocol.md](references/synthesis-protocol.md):
 
 - **ACCEPT**: The finding is valid and actionable
-- **REJECT**: The finding is a false positive or conflicts with project conventions
+- **REJECT**: The finding is a false positive or conflicts with project conventions — MUST attach a `Verification:` block per `protocol-quick-ref.md §verification-block`. Form B (verification-impossible) automatically downgrades to `deferred for verification`.
 
-Record each decision with reasoning in `claude_actions`.
+Record each decision with reasoning AND (for rejections) the `Verification:` block in `claude_actions[].verification`.
 
 ### Step 2.2: Implement accepted fixes
 
@@ -205,7 +217,7 @@ For each accepted finding:
 git add -A && git commit -m "review-loop: changes from round {N}" --allow-empty
 ```
 
-The `--allow-empty` flag ensures rounds where Claude only rejects findings (no code changes) don't fail.
+The `--allow-empty` flag ensures rounds where the host agent only rejects findings (no code changes) don't fail.
 
 ### Step 2.4: Update rounds.json
 
@@ -227,7 +239,7 @@ If round >= `max_rounds`:
 Use **Template 2** from [prompt-templates.md](references/prompt-templates.md):
 - Keep the template body fixed
 - Include only the files Claude changed this round via `git diff --name-only HEAD~1 HEAD`
-- Include rejected findings with Claude's reasoning
+- Include rejected findings with Claude's reasoning AND the verbatim `Verification:` block from `claude_actions[].verification` (so the peer can audit the evidence, not just the reasoning)
 - Include a short summary of accepted/fixed findings
 
 Do NOT paste the diff body into the prompt. Re-review should happen against the current local repository state.
@@ -259,7 +271,7 @@ Reuse the same Codex session for re-review rounds when available. This avoids re
 Look for:
 - `CONSENSUS:` → all resolved, go to Phase 3
 - `ACCEPTED_REJECTION: fN` → finding resolved, mark in rounds.json
-- `INSIST: fN` → peer insists, Claude must re-evaluate
+- `INSIST: fN` → peer insists, the host agent must re-evaluate
 - New `FINDING: fN` → new issues found in Claude's changes
 
 ### Step 2.9: Handle INSIST findings
@@ -309,14 +321,15 @@ Look for:
 - New `FINDING: fN` blocks → treat them as real blocking findings
 
 If the fresh final pass reports new findings:
-- If total rounds < `max_rounds`, append the findings as a new round and return to Phase 2.1
-- If total rounds >= `max_rounds`, mark them as `escalated` and continue with status `max_rounds`
+- **If `read_only: true`**: Record findings as `reported` in rounds.json. Do NOT return to Phase 2. Continue to report generation with status `read_only_complete`.
+- If `read_only: false` and total rounds < `max_rounds`, append the findings as a new round and return to Phase 2.1
+- If `read_only: false` and total rounds >= `max_rounds`, mark them as `escalated` and continue with status `max_rounds`
 
 ### Step 3.4: Complete rounds.json
 
 Update session metadata:
 - `completed_at`: current ISO timestamp
-- `status`: `consensus` or `max_rounds`
+- `status`: `consensus`, `max_rounds`, or `read_only_complete`
 - `total_rounds`: actual count
 - `summary`: compute totals from all rounds
 
@@ -347,11 +360,22 @@ Write `$SESSION_DIR/summary.md` in this format:
 {if consensus: "Both Claude Code and {peer} agree the code is in good shape after {N} rounds."}
 {if max_rounds: "Review stopped after {N} rounds. {M} items remain unresolved."}
 
+{if summary.deferred_for_verification > 0:}
+## Deferred for Verification
+
+{for each finding with action == "deferred for verification": bullet with
+  - finding id and title
+  - peer's authority-only argument (the original finding description)
+  - host's Form B `reason` (why verification was not possible)
+  - note: "auto-downgraded per synthesis-protocol.md — peer is NOT required to re-evaluate; surfaced here for human follow-up."}
+
 {if escalated items exist:}
 ## Escalated Items (Needs Human Decision)
 
 {for each escalated finding: peer's argument, Claude's argument, recommendation}
 ```
+
+The Deferred for Verification section is conditional: omit it entirely when `summary.deferred_for_verification == 0`. This section surfaces rejections that were auto-downgraded because they relied on authority (spec/design/conventions) without empirical proof per [protocol-quick-ref.md §verification-block](../harness/references/protocol-quick-ref.md#verification-block) Form B and [synthesis-protocol.md §Rejection Requirements](references/synthesis-protocol.md).
 
 ### Step 3.6: Terminal output
 

--- a/plugins/harness-engineering-skills/skills/review-loop/references/log-schema.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/references/log-schema.md
@@ -1,6 +1,7 @@
 # Review Loop — JSON Log Schema
 
 This defines the structure of `rounds.json`, the structured log file created in each review session.
+The field name `claude_actions` is retained for backward compatibility even when Codex is the host agent.
 
 ## File Location
 
@@ -16,7 +17,7 @@ This defines the structure of `rounds.json`, the structured log file created in 
     "id": "<YYYY-MM-DD>-<HHMMSS>-<scope-description>",
     "scope": "local-diff | pr-<number> | commit-<sha>",
     "scope_detail": "human-readable summary, e.g. '3 files changed, 42 insertions'",
-    "peer": "codex | gemini",
+    "peer": "codex | claude | gemini",
     "started_at": "ISO 8601 timestamp",
     "completed_at": "ISO 8601 timestamp (null if in_progress)",
     "status": "in_progress | consensus | max_rounds | aborted",
@@ -40,9 +41,10 @@ This defines the structure of `rounds.json`, the structured log file created in 
       "claude_actions": [
         {
           "finding_id": "f<N>",
-          "action": "accept | reject",
-          "reasoning": "Why Claude accepted or rejected this finding",
-          "code_changes": ["file:line-range that was modified (if accepted)"]
+          "action": "accept | reject | reported | deferred for verification",
+          "reasoning": "Why Claude accepted or rejected this finding (empty for reported)",
+          "verification": "Inline Verification: block (Form A or Form B per protocol-quick-ref.md §verification-block) — REQUIRED for action=reject; OPTIONAL for accept/reported; Form B presence triggers auto-downgrade from reject to 'deferred for verification'",
+          "code_changes": ["file:line-range that was modified (if accepted, empty for reported)"]
         }
       ]
     }
@@ -52,6 +54,8 @@ This defines the structure of `rounds.json`, the structured log file created in 
     "accepted": 0,
     "rejected_then_resolved": 0,
     "escalated": 0,
+    "reported": 0,
+    "deferred_for_verification": 0,
     "files_modified": ["list of files that were changed"]
   }
 }
@@ -67,6 +71,7 @@ This defines the structure of `rounds.json`, the structured log file created in 
 | `consensus` | Both agents agree — review complete |
 | `max_rounds` | Hit MAX_ROUNDS limit, some items may be unresolved |
 | `aborted` | Review was cancelled (timeout, error, user interrupt) |
+| `read_only_complete` | Read-only mode — findings reported, no code changes made |
 
 ### peer_findings[].severity
 
@@ -81,8 +86,10 @@ This defines the structure of `rounds.json`, the structured log file created in 
 
 | Action | Meaning |
 |--------|---------|
-| `accept` | Claude agrees and will implement the fix |
-| `reject` | Claude disagrees, provides reasoning to peer |
+| `accept` | Host agent agrees and will implement the fix |
+| `reject` | Host agent disagrees, provides reasoning to peer, AND attaches a `Verification:` block in `claude_actions[].verification` per [protocol-quick-ref.md §verification-block](../../harness/references/protocol-quick-ref.md#verification-block). Form B (verification-impossible) triggers auto-downgrade to `deferred for verification` — see [synthesis-protocol.md §Rejection Requirements](./synthesis-protocol.md). |
+| `reported` | Finding recorded without action (read-only mode) |
+| `deferred for verification` | Finding is not blocking but remains unresolved; peer is NOT required to re-evaluate; surfaced in summary.md's Deferred for Verification section. Produced by auto-downgrade of an authority-only rejection per [synthesis-protocol.md §Rejection Requirements](../references/synthesis-protocol.md) (Form B Verification: block — see [protocol-quick-ref.md §verification-block](../../harness/references/protocol-quick-ref.md#verification-block)). |
 
 ## Example
 

--- a/plugins/harness-engineering-skills/skills/review-loop/references/prompt-templates.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/references/prompt-templates.md
@@ -1,7 +1,7 @@
 # Review Loop — Prompt Templates
 
-Templates used by Claude Code to communicate with the peer reviewer (Codex/Gemini).
-Keep these templates stable. Claude should fill only the lightweight runtime placeholders before sending to peer via `peer-invoke.sh`.
+Templates used by the host agent to communicate with the peer reviewer (Codex/Claude/Gemini).
+Keep these templates stable. The host agent should fill only the lightweight runtime placeholders before sending to peer via `peer-invoke.sh`.
 
 ---
 
@@ -55,9 +55,9 @@ NO_FINDINGS: Code looks good. No issues detected.
 
 ---
 
-## Template 2: Re-review (After Claude Made Changes)
+## Template 2: Re-review (After the Host Agent Made Changes)
 
-Used in Round 2+ when Claude has addressed some findings and rejected others. Re-review should reuse the same peer session when possible.
+Used in Round 2+ when the host agent has addressed some findings and rejected others. Re-review should reuse the same peer session when possible.
 
 ```markdown
 You previously reviewed code and found issues. The primary developer has:
@@ -76,8 +76,10 @@ Review scope: {scope_type} ({scope_detail})
 [ACCEPTED AND FIXED]
 {accepted_findings_summary}
 
-[REJECTED FINDINGS WITH REASONING]
+[REJECTED FINDINGS WITH REASONING AND VERIFICATION]
 {rejected_findings_with_reasoning}
+
+Each rejected finding below includes a `Verification:` block (Form A or Form B per `protocol-quick-ref.md §verification-block`). Audit the verification output — not just the reasoning — when deciding whether to `ACCEPTED_REJECTION` or `INSIST`.
 
 [INSTRUCTIONS]
 1. Re-open the current local files, starting with the files listed above.
@@ -139,7 +141,7 @@ Please respond with ONE of:
 | `{target_files}` | Preflight file list | Newline-separated files for the peer to inspect locally |
 | `{project_context}` | CLAUDE.md + key config files | Project conventions and rules |
 | `{round_target_files}` | `git diff --name-only HEAD~1 HEAD` or latest touched files | Files to re-open during re-review |
-| `{accepted_findings_summary}` | rounds.json claude_actions where action=accept | List of what was fixed |
-| `{rejected_findings_with_reasoning}` | rounds.json claude_actions where action=reject | Rejections with reasoning |
+| `{accepted_findings_summary}` | rounds.json claude_actions where action=accept | List of what was fixed (`claude_actions` is the historical schema field name) |
+| `{rejected_findings_with_reasoning}` | rounds.json claude_actions where action=reject | Each entry includes reasoning AND the verbatim `Verification:` block from `claude_actions[].verification` (`claude_actions` is the historical schema field name) |
 | `{final_target_files}` | Union of files touched across the session | Files to verify in the final consensus round |
 | `{resolution_table_rows}` | Generated from rounds.json summary | Markdown table rows |

--- a/plugins/harness-engineering-skills/skills/review-loop/references/synthesis-protocol.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/references/synthesis-protocol.md
@@ -1,12 +1,12 @@
 # Review Loop — Synthesis Protocol
 
-How Claude Code evaluates peer findings, modifies code, and drives convergence.
+How the host agent evaluates peer findings, modifies code, and drives convergence.
 
 ---
 
 ## 1. Finding Evaluation Criteria
 
-For each peer finding, Claude evaluates and decides **ACCEPT** or **REJECT**.
+For each peer finding, the host agent evaluates and decides **ACCEPT** or **REJECT**.
 
 ### ACCEPT when:
 
@@ -27,10 +27,15 @@ For each peer finding, Claude evaluates and decides **ACCEPT** or **REJECT**.
 
 ### Rejection Requirements
 
-Every rejection MUST include:
-1. **Specific reasoning** — not "I disagree" but "this is a false positive because X"
-2. **Evidence** — reference to code, docs, or conventions that support the rejection
-3. **Openness** — acknowledge if the peer has a point but explain the trade-off
+Every rejection MUST include a Verification: block per protocol-quick-ref.md §verification-block. Authority-only rejections (references to spec/design/conventions without verification output) are auto-downgraded to "deferred for verification".
+
+Supporting expectations around that block:
+
+1. **Specific reasoning** — the `contradiction-explanation` field must say "this is a false positive because X", not "I disagree".
+2. **Evidence** — the `command` and `output` fields back the reasoning with empirical proof; a reference to code, docs, or conventions ALONE is Form B (authority-only) and triggers the auto-downgrade.
+3. **Openness** — acknowledge if the peer has a point but explain the trade-off; a contradictory peer argument does not excuse omitting the Verification: block.
+
+When verification is genuinely impossible (no network, no access, load-dependent behavior), use Form B with a `reason` field. The finding is NOT recorded as `rejected` in rounds.json — it is recorded as `deferred for verification` (see [log-schema.md](log-schema.md#claude_actionsaction)) and surfaced in summary.md's "Deferred for Verification" section.
 
 ---
 
@@ -52,6 +57,7 @@ Every rejection MUST include:
 ### After modifying code:
 
 - Record exactly which files and lines were changed in `claude_actions.code_changes`
+  - `claude_actions` is the historical schema field name even when Codex hosts the loop
 - The next peer round should receive the updated local workspace plus the list of files touched this round
 
 ---
@@ -67,15 +73,15 @@ Every rejection MUST include:
 ### Per-finding resolution flow:
 
 ```
-Finding → Claude ACCEPT → Code changed → Peer re-reviews
+Finding → Host ACCEPT → Code changed → Peer re-reviews
   └── Peer satisfied → RESOLVED
   └── Peer has concerns about fix → New finding in next round
 
-Finding → Claude REJECT (with reasoning) → Sent to peer
+Finding → Host REJECT (with reasoning) → Sent to peer
   └── Peer: ACCEPTED_REJECTION → RESOLVED
-  └── Peer: INSIST (round 1) → Claude re-evaluates
-       └── Claude changes mind → ACCEPT → Code changed
-       └── Claude still disagrees → Send stronger reasoning
+  └── Peer: INSIST (round 1) → Host re-evaluates
+       └── Host changes mind → ACCEPT → Code changed
+       └── Host still disagrees → Send stronger reasoning
             └── Peer: ACCEPTED_REJECTION → RESOLVED
             └── Peer: INSIST (round 2) → ESCALATED
 ```
@@ -103,8 +109,8 @@ A finding is marked **ESCALATED** (needs human decision) when:
 
 - Debated for 2+ rounds without resolution (STALEMATE)
 - Involves an architectural decision beyond a code-level fix
-- Security concern where Claude cannot definitively determine correctness
-- Peer and Claude have fundamentally different interpretations of requirements
+- Security concern where the host agent cannot definitively determine correctness
+- Peer and host agent have fundamentally different interpretations of requirements
 
 ### Escalation format in summary.md:
 
@@ -113,7 +119,7 @@ A finding is marked **ESCALATED** (needs human decision) when:
 
 ### Finding f3: Database connection pool sizing
 - **Peer says**: Pool size of 10 is too low for expected load
-- **Claude says**: Pool size matches current infrastructure limits
+- **Host says**: Pool size matches current infrastructure limits
 - **Rounds debated**: 2
 - **Recommendation**: Review with infrastructure team before changing
 ```
@@ -122,7 +128,7 @@ A finding is marked **ESCALATED** (needs human decision) when:
 
 ## 5. Round Execution Checklist
 
-Claude follows this for each round:
+The host agent follows this for each round:
 
 - [ ] Read peer output from `peer-output/round-N-raw.txt`
 - [ ] Parse findings (look for `FINDING:`, `CONSENSUS:`, `ACCEPTED_REJECTION:`, `INSIST:`)

--- a/plugins/harness-engineering-skills/skills/review-loop/scripts/peer-invoke.sh
+++ b/plugins/harness-engineering-skills/skills/review-loop/scripts/peer-invoke.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# peer-invoke.sh — Thin wrapper for Codex/Gemini CLI invocation
+# peer-invoke.sh — Thin wrapper for Codex/Claude/Gemini CLI invocation
 # Abstracts CLI differences so SKILL.md doesn't care which peer is used.
-# Codex inspects local files directly from the current repository workspace.
+# Peers inspect local files directly from the current repository workspace.
 #
 # Exit codes: 0=success, 1=error, 124=timeout
 #
 # Usage:
 #   ./peer-invoke.sh --peer codex --prompt-file /tmp/prompt.md \
+#     --output-file .review-loop/session/peer-output/round-1-raw.txt --timeout 600
+#   ./peer-invoke.sh --peer claude --prompt-file /tmp/prompt.md \
 #     --output-file .review-loop/session/peer-output/round-1-raw.txt --timeout 600
 #   ./peer-invoke.sh --peer codex --resume-session <session-id> \
 #     --prompt-file /tmp/reround.md --output-file .review-loop/session/peer-output/round-2-raw.txt
@@ -80,11 +82,15 @@ PROMPT_CONTENT="$(cat "$PROMPT_FILE")"
 
 TEMP_CODEX_HOME=""
 RUN_LOG=""
+RUN_ERR=""
 peer_exit_code=0
 
 cleanup() {
   if [[ -n "$RUN_LOG" && -f "$RUN_LOG" ]]; then
     rm -f "$RUN_LOG"
+  fi
+  if [[ -n "$RUN_ERR" && -f "$RUN_ERR" ]]; then
+    rm -f "$RUN_ERR"
   fi
   if [[ -n "$TEMP_CODEX_HOME" && -d "$TEMP_CODEX_HOME" ]]; then
     rm -rf "$TEMP_CODEX_HOME"
@@ -141,6 +147,82 @@ extract_session_id() {
   awk -F': ' '/^session id:/ { print $2; exit }' "$log_file"
 }
 
+parse_claude_json() {
+  local log_file="$1"
+  local output_file="$2"
+  local session_id_file="${3:-}"
+
+  python3 - "$log_file" "$output_file" "$session_id_file" <<'PY'
+import json
+import pathlib
+import sys
+
+log_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+session_id_path = pathlib.Path(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else None
+
+text = log_path.read_text()
+try:
+    payload = json.loads(text)
+    events = payload if isinstance(payload, list) else [payload]
+except json.JSONDecodeError:
+    events = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+session_id = ""
+result_text = None
+is_error = False
+
+for event in events:
+    if isinstance(event, dict):
+        session_id = event.get("session_id") or session_id
+        if event.get("type") == "result":
+            is_error = bool(event.get("is_error"))
+            result_text = event.get("result")
+            session_id = event.get("session_id") or session_id
+
+if result_text is None:
+    for event in reversed(events):
+        if not isinstance(event, dict):
+            continue
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        text_parts = [
+            part.get("text", "")
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        ]
+        if text_parts:
+            result_text = "\n".join(part for part in text_parts if part)
+            session_id = event.get("session_id") or session_id
+            break
+
+if result_text is None:
+    print("Error: Claude output did not include a result payload", file=sys.stderr)
+    sys.exit(1)
+
+output_path.write_text(result_text)
+
+if session_id_path:
+    session_id_path.parent.mkdir(parents=True, exist_ok=True)
+    session_id_path.write_text(f"{session_id}\n")
+
+if is_error:
+    print(f"Error: Claude peer returned an error: {result_text}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
 case "$PEER" in
   codex)
     command -v codex &>/dev/null || { echo "Error: codex CLI not found. Install: npm i -g @openai/codex" >&2; exit 1; }
@@ -184,13 +266,45 @@ case "$PEER" in
       fi
     fi
     ;;
+  claude)
+    command -v claude &>/dev/null || { echo "Error: claude CLI not found" >&2; exit 1; }
+    RUN_LOG="$(mktemp "${TMPDIR:-/tmp}/review-loop-claude-log.XXXXXX")"
+    RUN_ERR="$(mktemp "${TMPDIR:-/tmp}/review-loop-claude-stderr.XXXXXX")"
+    cd "$REPO_ROOT" || exit 1
+
+    CLAUDE_ARGS=(-p --output-format "${REVIEW_LOOP_CLAUDE_OUTPUT_FORMAT:-stream-json}")
+    if [[ "${REVIEW_LOOP_CLAUDE_SKIP_PERMISSIONS:-1}" == "1" ]]; then
+      CLAUDE_ARGS+=(--dangerously-skip-permissions)
+    fi
+    if [[ "${REVIEW_LOOP_CLAUDE_OUTPUT_FORMAT:-stream-json}" == "stream-json" ]]; then
+      CLAUDE_ARGS+=(--verbose)
+    fi
+
+    if [[ -n "$RESUME_SESSION" ]]; then
+      $TIMEOUT_CMD "$TIMEOUT" claude -r "$RESUME_SESSION" "${CLAUDE_ARGS[@]}" \
+        < "$PROMPT_FILE" > "$RUN_LOG" 2> "$RUN_ERR"
+    else
+      $TIMEOUT_CMD "$TIMEOUT" claude "${CLAUDE_ARGS[@]}" \
+        < "$PROMPT_FILE" > "$RUN_LOG" 2> "$RUN_ERR"
+    fi
+    peer_exit_code=$?
+
+    cat "$RUN_LOG" >&2
+    cat "$RUN_ERR" >&2
+
+    if [[ $peer_exit_code -eq 0 ]]; then
+      if ! parse_claude_json "$RUN_LOG" "$OUTPUT_FILE" "$SESSION_ID_FILE"; then
+        peer_exit_code=1
+      fi
+    fi
+    ;;
   gemini)
     command -v gemini &>/dev/null || { echo "Error: gemini CLI not found" >&2; exit 1; }
     $TIMEOUT_CMD "$TIMEOUT" gemini -p "$PROMPT_CONTENT" > "$OUTPUT_FILE" 2>&1
     peer_exit_code=$?
     ;;
   *)
-    echo "Error: Unsupported peer: $PEER. Use 'codex' or 'gemini'." >&2
+    echo "Error: Unsupported peer: $PEER. Use 'codex', 'claude', or 'gemini'." >&2
     exit 1
     ;;
 esac

--- a/plugins/harness-engineering-skills/skills/review-loop/scripts/preflight.sh
+++ b/plugins/harness-engineering-skills/skills/review-loop/scripts/preflight.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 # Also creates the session directory and writes rounds.json.
 #
 # Usage:
-#   ./preflight.sh [--peer codex|gemini] [--max-rounds N]
+#   ./preflight.sh [--peer codex|claude|gemini] [--max-rounds N]
 #                  [--scope auto|diff|branch|pr] [--timeout N]
 #                  [--commit-sha SHA]
 
@@ -19,6 +19,7 @@ MAX_ROUNDS=5
 SCOPE_PREF="auto"
 TIMEOUT=600
 COMMIT_SHA=""
+READ_ONLY="false"
 
 # 2. Merge project config over defaults
 CONFIG_FILE=".review-loop/config.json"
@@ -26,9 +27,11 @@ if [[ -f "$CONFIG_FILE" ]]; then
   cfg_peer=$(grep -o '"peer_reviewer"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG_FILE" 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"')
   cfg_max=$(grep -o '"max_rounds"[[:space:]]*:[[:space:]]*[0-9]*' "$CONFIG_FILE" 2>/dev/null | grep -o '[0-9]*$')
   cfg_timeout=$(grep -o '"timeout_per_round"[[:space:]]*:[[:space:]]*[0-9]*' "$CONFIG_FILE" 2>/dev/null | grep -o '[0-9]*$')
+  cfg_readonly=$(grep -o '"read_only"[[:space:]]*:[[:space:]]*true' "$CONFIG_FILE" 2>/dev/null)
   [[ -n "${cfg_peer:-}" ]] && PEER="$cfg_peer"
   [[ -n "${cfg_max:-}" ]] && MAX_ROUNDS="$cfg_max"
   [[ -n "${cfg_timeout:-}" ]] && TIMEOUT="$cfg_timeout"
+  [[ -n "${cfg_readonly:-}" ]] && READ_ONLY="true"
 fi
 
 # 3. CLI args override everything (highest precedence)
@@ -39,44 +42,48 @@ while [[ $# -gt 0 ]]; do
     --scope)      SCOPE_PREF="$2"; shift 2 ;;
     --timeout)    TIMEOUT="$2"; shift 2 ;;
     --commit-sha) COMMIT_SHA="$2"; shift 2 ;;
+    --read-only)     READ_ONLY="true"; shift ;;
+    --no-read-only)  READ_ONLY="false"; shift ;;
     *) echo "Error: Unknown option: $1" >&2; exit 1 ;;
   esac
 done
 
-# --- Step 0.1b: Validate peer against the allowlist shipped by the skill ---
-# peer-invoke.sh only supports codex and gemini; reject anything else here
-# so we don't create a session / checkpoint commit for an unsupported peer.
-case "$PEER" in
-  codex|gemini) ;;
-  *)
-    echo "Error: Unsupported peer '$PEER'. Supported: codex, gemini." >&2
-    exit 1
-    ;;
-esac
-
 # --- Step 0.2: Check peer CLI ---
 if ! command -v "$PEER" &>/dev/null; then
-  # Try alternative
-  if [[ "$PEER" == "codex" ]] && command -v gemini &>/dev/null; then
-    echo "Warning: codex not found, falling back to gemini" >&2
-    PEER="gemini"
-  elif [[ "$PEER" == "gemini" ]] && command -v codex &>/dev/null; then
-    echo "Warning: gemini not found, falling back to codex" >&2
-    PEER="codex"
-  else
-    echo "Error: Neither codex nor gemini CLI found" >&2
-    exit 1
-  fi
+  for fallback in codex claude gemini; do
+    [[ "$fallback" == "$PEER" ]] && continue
+    if command -v "$fallback" &>/dev/null; then
+      echo "Warning: $PEER not found, falling back to $fallback" >&2
+      PEER="$fallback"
+      break
+    fi
+  done
+fi
+
+if ! command -v "$PEER" &>/dev/null; then
+  echo "Error: None of codex, claude, or gemini CLI found" >&2
+  exit 1
 fi
 
 # --- Step 0.3: Detect base branch and repo root ---
+# Try origin/HEAD first, then common branch names on the remote, then local-only branches
 BASE_BRANCH="$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||')"
+if [[ "$BASE_BRANCH" == "HEAD" || "$BASE_BRANCH" == "origin/HEAD" ]]; then
+  BASE_BRANCH=""
+fi
 if [[ -z "$BASE_BRANCH" ]]; then
   for branch in main master develop; do
     git rev-parse --verify "origin/$branch" &>/dev/null && BASE_BRANCH="$branch" && break
   done
 fi
-BASE_BRANCH="${BASE_BRANCH:-main}"
+# Fallback for repos without a remote: detect local main/master branch
+if [[ -z "$BASE_BRANCH" ]]; then
+  for branch in main master; do
+    git rev-parse --verify "$branch" &>/dev/null && BASE_BRANCH="$branch" && break
+  done
+fi
+BASE_BRANCH="${BASE_BRANCH:-HEAD}"
+HAS_REMOTE="$(git remote 2>/dev/null | head -1)"
 REPO_ROOT="$(pwd -P)"
 
 # --- Step 0.4: Detect scope ---
@@ -87,23 +94,13 @@ TARGET_FILES=""
 if [[ "$SCOPE_PREF" == "auto" || "$SCOPE_PREF" == "diff" ]]; then
   LOCAL_DIFF="$(git diff --stat 2>/dev/null)"
   STAGED_DIFF="$(git diff --cached --stat 2>/dev/null)"
-  UNTRACKED_FILES="$(git ls-files --others --exclude-standard 2>/dev/null)"
-  if [[ -n "$LOCAL_DIFF" || -n "$STAGED_DIFF" || -n "$UNTRACKED_FILES" ]]; then
+  if [[ -n "$LOCAL_DIFF" || -n "$STAGED_DIFF" ]]; then
     SCOPE="local-diff"
-    UNTRACKED_COUNT="$(printf '%s\n' "$UNTRACKED_FILES" | sed '/^$/d' | awk 'NF{n++} END{print n+0}')"
-    DIFF_STAT="$(printf '%s\n%s\n' "$LOCAL_DIFF" "$STAGED_DIFF" | sed '/^$/d' | tail -1)"
-    if [[ -n "$DIFF_STAT" && -n "$UNTRACKED_FILES" ]]; then
-      SCOPE_DETAIL="${DIFF_STAT}; ${UNTRACKED_COUNT} untracked"
-    elif [[ -n "$DIFF_STAT" ]]; then
-      SCOPE_DETAIL="$DIFF_STAT"
-    else
-      SCOPE_DETAIL="${UNTRACKED_COUNT} untracked file(s)"
-    fi
+    SCOPE_DETAIL="$(printf '%s\n%s\n' "$LOCAL_DIFF" "$STAGED_DIFF" | sed '/^$/d' | tail -1)"
     TARGET_FILES="$(
       {
         git diff --name-only 2>/dev/null
         git diff --cached --name-only 2>/dev/null
-        printf '%s\n' "$UNTRACKED_FILES"
       } | sed '/^$/d' | sort -u
     )"
   fi
@@ -121,14 +118,27 @@ if [[ -z "$SCOPE" && -n "$COMMIT_SHA" ]]; then
   fi
 fi
 
-# Branch has unpushed commits
+# Branch has unpushed commits (or local-only commits when no remote)
 if [[ -z "$SCOPE" && ("$SCOPE_PREF" == "auto" || "$SCOPE_PREF" == "branch") ]]; then
-  BRANCH_LOG="$(git log "origin/$BASE_BRANCH..HEAD" --oneline 2>/dev/null)"
+  if [[ -n "$HAS_REMOTE" ]]; then
+    BRANCH_LOG="$(git log "origin/$BASE_BRANCH..HEAD" --oneline 2>/dev/null)"
+    BRANCH_DIFF_REF="origin/$BASE_BRANCH"
+  else
+    # No remote: compare current branch against local base branch (if different from HEAD)
+    CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    if [[ "$CURRENT_BRANCH" != "$BASE_BRANCH" && "$BASE_BRANCH" != "HEAD" ]]; then
+      BRANCH_LOG="$(git log "$BASE_BRANCH..HEAD" --oneline 2>/dev/null)"
+      BRANCH_DIFF_REF="$BASE_BRANCH"
+    else
+      BRANCH_LOG=""
+      BRANCH_DIFF_REF=""
+    fi
+  fi
   if [[ -n "$BRANCH_LOG" ]]; then
     SCOPE="branch-commits"
     COMMIT_COUNT="$(echo "$BRANCH_LOG" | wc -l | tr -d ' ')"
-    SCOPE_DETAIL="${COMMIT_COUNT} commits ahead of origin/$BASE_BRANCH"
-    TARGET_FILES="$(git diff --name-only "origin/$BASE_BRANCH..HEAD" 2>/dev/null | sed '/^$/d')"
+    SCOPE_DETAIL="${COMMIT_COUNT} commits ahead of ${BRANCH_DIFF_REF}"
+    TARGET_FILES="$(git diff --name-only "${BRANCH_DIFF_REF}..HEAD" 2>/dev/null | sed '/^$/d')"
   fi
 fi
 
@@ -163,7 +173,12 @@ mkdir -p "$SESSION_DIR/peer-output"
 ln -sfn "$SESSION_ID" .review-loop/latest
 
 # --- Step 0.6: Auto-gitignore ---
-grep -qxF '.review-loop/' .gitignore 2>/dev/null || echo '.review-loop/' >> .gitignore
+# Track whether we actually modified .gitignore (matters for read-only mode)
+GITIGNORE_MODIFIED="false"
+if ! grep -qxF '.review-loop/' .gitignore 2>/dev/null; then
+  echo '.review-loop/' >> .gitignore
+  GITIGNORE_MODIFIED="true"
+fi
 
 # --- Step 0.7: Initialize rounds.json ---
 STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -185,17 +200,19 @@ cat > "$SESSION_DIR/rounds.json" << ENDJSON
     "accepted": 0,
     "rejected_then_resolved": 0,
     "escalated": 0,
+    "reported": 0,
     "files_modified": []
   }
 }
 ENDJSON
 
 # --- Step 0.8: Checkpoint commit ---
-# Use `-a` (modifications/deletions of tracked files only) instead of `add -A`
-# to avoid sweeping untracked files — which may contain secrets (.env, creds) —
-# into the checkpoint commit on the branch under review.
-git commit -am "review-loop: checkpoint before round 1" --allow-empty 2>/dev/null \
-  || git commit -m "review-loop: checkpoint before round 1" --allow-empty 2>/dev/null
+if [[ "$READ_ONLY" != "true" ]]; then
+  git add -A && git commit -m "review-loop: checkpoint before round 1" --allow-empty 2>/dev/null
+elif [[ "$GITIGNORE_MODIFIED" == "true" ]]; then
+  # In read-only mode, still commit the gitignore change to avoid leaving dirty state
+  git add .gitignore && git commit -m "review-loop: add .review-loop/ to gitignore" --allow-empty 2>/dev/null
+fi
 
 # --- Step 1.1: Collect project context ---
 PROJECT_DESC=""
@@ -224,6 +241,7 @@ SCOPE_DETAIL=${SCOPE_DETAIL}
 BASE_BRANCH=${BASE_BRANCH}
 REPO_ROOT=${REPO_ROOT}
 STARTED_AT=${STARTED_AT}
+READ_ONLY=${READ_ONLY}
 TARGET_FILES_B64_START
 ${TARGET_FILES_B64}
 TARGET_FILES_B64_END


### PR DESCRIPTION
## Summary

- End the private/public divergence by pulling forward every feature from the private `stometa-skillset` copy, while keeping this repo's plugin-bundled layout and agent resolution intact.
- `harness` 0.12.0 → **0.13.0**, `review-loop` 1.2.0 → **1.3.0**.
- After this lands, `stometa-skillset` will no longer carry its own copy — future iteration happens only here (see companion PR `stone16/stometa-skillset#<TBD>`).

## What moved in (logic from stometa-skillset)

- **harness**: Post-Brainstorming Autonomy, `Verification:` block enforcement on spec-reviewer rejections, `read_only_complete` acceptance in the review-loop phase gate, expanded `cross_model_peer` options (`codex` / `claude` / `gemini`), and a new Phase 5 Validation Claim Audit in `harness-spec-evaluator`.
- **review-loop**: `claude` CLI as a 3rd peer reviewer, `read_only` sensor mode, expanded peer-invoke / preflight flows.

## What stayed (preserved public architecture)

- `plugins/harness-engineering-skills/...` paths (no leaking `plugins/stometa-skillset/` references).
- 3-tier agent resolution in `claude-agent-invoke.sh` (user override → plugin-bundled → legacy dotfiles fallback).
- Prereqs unchanged (no `sto` plugin dependency).
- `begin-checkpoint` / `begin-e2e` / `pass-e2e` phase gates in `harness-engine.sh` (were not present in the private copy).

## Test plan

- [x] `bash -n` passes on all four bundled shell scripts (harness-engine.sh, claude-agent-invoke.sh, peer-invoke.sh, preflight.sh)
- [x] `grep -rn "plugins/stometa-skillset\\|stometa-private-marketplace\\|sto@stometa"` across `plugins/` returns empty
- [ ] Reinstall plugin locally and invoke `harness` / `review-loop` to smoke-test the merged content
- [ ] Verify the Phase 5 Validation Claim Audit triggers on a spec containing an unsupported `validated via ...` claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)