### PR TITLE
fix: batch of 7 harness-retro issues (generator, evaluator, checkpoint, review-loop)

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-evaluator.md
@@ -27,14 +27,18 @@ Be thorough and evidence-based. Every claim must be backed by test output, scree
 ## Focus Areas
 
 - **Tier 1 (deterministic)**: magnitude check, tests, type check, linter, browser verification, API verification
-- **Tier 2 (LLM review)**: edge cases, concurrency, security, performance, logic correctness, goal relevance
+- **Tier 2 (LLM review)**: edge cases, concurrency, security, performance, logic correctness, goal relevance, **fault-path probe for external-input code paths** (see Key Actions step 4)
 
 ## Key Actions
 
 1. Read the checkpoint spec (acceptance criteria) and Generator's output-summary.md
 2. Review the git diff to understand what changed
 3. **Tier 1**: First run magnitude check — read `effort_estimate` from context.md frontmatter, compute actual insertions and file count from `git diff --stat`, compare against 3× threshold (S=150/9, M=450/24, L=900/36). If exceeded → set REVIEW with goal-relevance focus. Then run tests, type check, linter. For frontend: use agent-browser to render and interact. For backend: call API endpoints and verify responses. Save all outputs to evidence/
-4. **Tier 2**: Deep code review — edge cases, race conditions, security vulnerabilities, performance implications, logic correctness vs spec intent
+4. **Tier 2**: Deep code review — edge cases, race conditions, security vulnerabilities, performance implications, logic correctness vs spec intent. **Fault-path probe is mandatory**: if the checkpoint's code reads or parses external input (files, env vars, stdin, arguments flowing into `jq`/`sed`/`awk`/`python`/bash parameter expansion, etc.), the Tier 2 review MUST include at least one of:
+   - A test in the CP's suite that feeds malformed input (invalid JSON, non-numeric version, trailing backslash, embedded newline, etc.) and asserts well-defined behaviour (error message + exit code, or graceful-degrade path); OR
+   - An evaluator-led simulation: run the code path with a hand-crafted malformed fixture and document stdout/stderr/exit code in `evaluation.md` under a **"Fault-path probe"** heading.
+
+   If the CP has **no** external input (pure computation, compile-time constants), state that explicitly in `evaluation.md` with one line (e.g. `Fault-path probe: N/A — pure computation`) so reviewers see the question was asked and answered. Specifically for atomic-writer patterns (`mktemp` + `mv`), verify the tempfile sits on the same filesystem as the target — a naked `mktemp` (defaults to `$TMPDIR`) produces a cross-fs `mv` that degrades to non-atomic copy+unlink.
 5. Write evaluation.md per protocol format
 6. Set verdict: PASS / FAIL / REVIEW
 7. **If REVIEW**: classify each review_item with structured fields:

--- a/plugins/harness-engineering-skills/agents/harness-generator.md
+++ b/plugins/harness-engineering-skills/agents/harness-generator.md
@@ -81,7 +81,13 @@ Prioritize correctness and spec compliance above all else. Write code that works
 - Add features not in the checkpoint scope
 - Refactor code outside the checkpoint's files of interest
 - Skip tests or commit failing code
-- Modify spec.md or harness protocol files
+- Modify spec.md
+- Modify harness protocol files (planning-protocol.md, execution-protocol.md,
+  codex-mode.md, protocol-quick-ref.md, checkpoint-definition.md) UNLESS the
+  checkpoint spec's Scope explicitly lists them. When explicitly scoped, the
+  Generator proceeds with the edit, keeps the change minimal and goal-bound,
+  and documents the override in output-summary.md's Rule Conflict Notes —
+  one sentence is sufficient, not a full paragraph.
 - Review specs or evaluate plans (that's the Spec Evaluator's job)
 
 ---

--- a/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
@@ -66,6 +66,26 @@ This means:
 - Generator **may** create new files if necessary to achieve the objective
 - Generator **must not** make improvements, refactoring, or optimizations unrelated to the objective — document these in output-summary.md under "Recommended Follow-up"
 
+### Infrastructure checkpoints editing protocol/reference documents
+
+When a checkpoint's Scope includes ≥2 harness protocol files, OR edits any
+file with known sibling cross-references (e.g., `planning-protocol.md` ↔
+`codex-mode.md` ↔ `protocol-quick-ref.md`, or similar reference-document
+clusters), the Generator MUST perform a sibling-scan after completing the
+primary edit:
+
+1. Grep sibling protocol files for the phrase/rule just edited.
+2. If the sibling contains the same concept, re-read the sibling to verify
+   it does not contradict the primary edit.
+3. If contradiction exists, either (a) propose extending Scope via
+   output-summary.md's Scope Expansion Request, OR (b) document the residual
+   contradiction in Rule Conflict Notes so E2E Evaluator surfaces it.
+
+This is particularly important for escalation rules, enum values, carrier
+field names, and exact-sentence contracts — the E2E Data-Flow Audit tracks
+named producer→consumer contracts, not unnamed sibling contradictions, so
+those divergences would otherwise slip through to review-loop or retro.
+
 ---
 
 ## Effort Estimate

--- a/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
@@ -166,6 +166,52 @@ Every checkpoint MUST include at least one testability criterion. Strategy diffe
 
 ---
 
+## Wiring Checkpoint — Multi-Layer Integration Pattern
+
+When a task has **≥5 checkpoints spanning ≥2 layers** (e.g., primitives in a
+lib layer + services in an app layer + hooks in a UI layer), the Planner
+MUST add a dedicated **Wiring Checkpoint** whose sole job is to verify that
+every primitive introduced by earlier checkpoints is invoked by its real
+production caller with the correct arguments, without mocking the seam
+under test.
+
+Module-boundary decomposition tends to leave "someone-else-will-wire-this-
+later" gaps — each CP ships a self-consistent primitive, but no CP owns
+end-to-end caller threading. Those gaps are hard to catch with isolated
+per-checkpoint validation and tend to survive internal full-verify because
+the integration smoke path still mocks the seams where the bugs live.
+
+### Wiring Checkpoint rules
+
+1. **No new primitives.** The Wiring CP only threads and verifies existing
+   ones. If the Wiring CP needs a new primitive, it belongs in a regular
+   checkpoint first.
+2. **Real-caller tests.** For each new primitive introduced by earlier
+   checkpoints, add a test that exercises its **real production caller**
+   and asserts the call shape and arguments (not a mock of the caller).
+3. **Caller-to-primitive verification matrix.** Include a table in the
+   Wiring CP's output-summary.md mapping each primitive to its production
+   caller and the test file that exercises that call.
+4. **Explicit mock boundaries.** List which layers are mocked in each test
+   and which are real. A top-level smoke test that mocks everything below
+   the entry point is **not** a wiring test for seams above the mocked
+   layer — flag those explicitly.
+
+### When to add a Wiring Checkpoint
+
+| Task shape | Wiring CP needed? |
+|---|---|
+| ≤4 checkpoints, single layer | No — per-CP integration tests suffice |
+| ≥5 checkpoints, single layer | Consider one if seams cross ≥2 concerns (e.g. DB + HTTP) |
+| ≥5 checkpoints, ≥2 layers | **Yes — add a dedicated Wiring CP as the last pre-E2E checkpoint** |
+| Any shape with a caller-threading gap pattern in retro history | Yes |
+
+The Wiring CP is typically the last checkpoint before E2E. Failed wiring is
+much cheaper to diagnose at this stage than at E2E where multiple layers
+are in play simultaneously.
+
+---
+
 ## Checkpoint Format (in spec.md)
 
 ```markdown

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -266,6 +266,7 @@ Each section has: ran, passed/results, errors/failures, **evidence** (path in ev
 ### Tier 2: LLM Code Review
 
 - patterns_checked, issues_found (severity: critical|warning|info), positive_observations, evidence
+- **fault_path_probe** (MANDATORY field): for any code path that reads/parses external input (files, env vars, stdin, arguments into `jq`/`sed`/`awk`/`python`/bash parameter expansion), record either (a) the malformed-input test in the CP's suite and its asserted behaviour, OR (b) the evaluator-led simulation (command + stdout/stderr + exit code) under a `Fault-path probe` heading with evidence in `evidence/`. For CPs with no external input (pure computation, compile-time constants), fill this field with one explicit line: `N/A — pure computation` (or similar). Atomic-writer patterns (`mktemp` + `mv`) must additionally verify the tempfile is on the same filesystem as the target — naked `mktemp` defaults to `$TMPDIR` and produces a non-atomic cross-fs copy+unlink.
 
 ### Verdict
 

--- a/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
@@ -378,6 +378,17 @@ Write `$SESSION_DIR/summary.md` in this format:
 |---|---------|----------|--------|------------|
 {for each finding: row with id, title, severity, accept/reject, final status}
 
+## Round Breakdown
+
+| Source | Real issues found |
+|--------|-------------------|
+| Resumed-session rounds (r1–rN)   | {resumed_real_issue_count} |
+| Fresh-final consensus pass       | {fresh_final_real_issue_count} |
+
+Fresh-final contributed {fresh_final_real_issue_count}/{total_real_issue_count} real issues this session.
+
+Count only findings that survived host evaluation (action=accept, or action=reject with Form B deferral). Exclude findings where the host's Form A verification produced empirical contradiction — those were peer false positives, not "real issues" for this purpose. The point of this breakdown is to track how much signal fresh-final finds that resumed rounds miss, so the load-bearing invariant in Phase 3 Documentation / Protocol Scope Rule stays visibly justified across sessions.
+
 ## Consensus
 
 {if consensus: "Both Claude Code and {peer} agree the code is in good shape after {N} rounds."}

--- a/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
@@ -287,6 +287,29 @@ Then loop back to Step 2.1 with the updated findings list.
 
 ## Phase 3: Final Consensus + Report
 
+### Documentation / Protocol Scope Rule (load-bearing invariant)
+
+When the review scope targets documentation or protocol files — defined as
+any `.md` file under a skill's `references/`, `agents/`, or a repo-level
+`dotfiles/` directory — fresh-final consensus (Step 3.2) is **load-bearing
+and non-optional**. Historical evidence: on PR #42 the `codex-mode.md` ↔
+`planning-protocol.md` escalation-rule contradiction (`rFinal.f1`) was
+caught only by fresh-final; resumed-session rounds had converged on
+CONSENSUS while the bug was still shipping.
+
+Operational implications:
+
+- Step 3.2 MUST run in a fresh peer session even if earlier rounds
+  converged cleanly. Any future optimization that would skip fresh-final
+  under "all rounds resolved quickly" heuristics MUST exclude this scope.
+- If fresh-final reports new findings on docs/protocol scope with
+  `read_only: false`, treat them as a new iteration round per Step 3.3 —
+  Consensus is reached only when a fresh session returns zero findings.
+- In `read_only: true` mode, fresh-final findings on docs/protocol scope
+  MUST be surfaced in summary.md with the explicit note that these would
+  have been blockers in normal mode — do not let them disappear silently
+  into the generic `reported` bucket.
+
 ### Step 3.1: Build final consensus prompt
 
 Use **Template 3** from [prompt-templates.md](references/prompt-templates.md).

--- a/plugins/harness-engineering-skills/skills/review-loop/references/prompt-templates.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/references/prompt-templates.md
@@ -33,10 +33,18 @@ Review scope: {scope_type} ({scope_detail})
 {project_context}
 
 [WORKSPACE INSTRUCTIONS]
-1. Start with the listed files and read the local code directly from the workspace.
-2. Open adjacent files as needed to understand behavior and contracts.
-3. Judge the current code state in the repository, not a pasted patch.
-4. Do not make code changes unless explicitly instructed elsewhere.
+1. Read ONLY the files listed under [PRIORITY FILES TO INSPECT]. Do not
+   wander into adjacent files. If a specific finding genuinely requires
+   verifying a contract in a sibling file, read the minimum necessary
+   (one file, the relevant section) — do not recurse further.
+2. Treat the repository root above (`{repo_root}`) as the workspace
+   boundary. In a monorepo subdirectory (e.g. running inside a workspace
+   package), do NOT read project-level siblings above this root. Paths
+   outside the listed files that would require `../` traversal are out
+   of scope.
+3. Judge the current code state directly from these files, not from an
+   embedded diff.
+4. Do not make code changes.
 
 [OUTPUT FORMAT]
 Return findings as a structured list. For EACH finding use this exact format:
@@ -117,6 +125,12 @@ Repository root: {repo_root}
 
 [FILES TO VERIFY]
 {final_target_files}
+
+[SCOPE DISCIPLINE]
+Read ONLY the files listed above. Do not wander into adjacent files, and in
+a monorepo subdirectory do not traverse above the repository root. Expand
+only the minimum necessary (one file, one section) to verify a specific
+remaining contract — then stop.
 
 [RESOLUTION SUMMARY]
 | Finding | Severity | Resolution |


### PR DESCRIPTION
## Summary

Batch of 7 harness-retro rule adoptions, one commit per issue for clean traceability.

## Issues resolved

| Commit | Source issue | Topic |
|---|---|---|
| 30873c3 | [stometa-skillset#43](https://github.com/stone16/stometa-skillset/issues/43) | Generator `Will Not` clause: spec-scoped protocol file exception |
| ffc0dce | [stometa-skillset#44](https://github.com/stone16/stometa-skillset/issues/44) | Sibling-scan protocol for protocol-doc checkpoints |
| a083472 | [harness-engineering-skills#3](https://github.com/stone16/harness-engineering-skills/issues/3) | Dedicated Wiring Checkpoint for multi-layer tasks |
| 89a0be9 | [optiminds#14](https://github.com/Optiminds-Inc/optiminds-repo-template/issues/14) (skill-level, also covers #9) | Evaluator fault-path probe for external-input code |
| 66adc3a | [stometa-skillset#46](https://github.com/stone16/stometa-skillset/issues/46) | Fresh-final as load-bearing for docs/protocol scope |
| 56706aa | [stometa-skillset#30](https://github.com/stone16/stometa-skillset/issues/30) | Review-loop monorepo scope containment |
| 64fbf4c | [optiminds#13](https://github.com/Optiminds-Inc/optiminds-repo-template/issues/13) | Fresh-vs-resumed breakdown in summary.md |

## Scope

6 files, +132 / -7 lines. All additive or narrow edits to protocol docs
and agent definitions. No code changes in `scripts/` or `hooks/`.

Each commit is atomic and independently revertable; bisect-friendly.

## Testing verification

This PR edits documentation and agent-definition `.md` files. There are
no executable tests in this repo (skills-only plugin). Review-loop is
the correct tool to validate these doc changes — that will run in a
follow-up.

## Test plan
- [ ] Reviewer reads each commit and confirms the rule matches the linked issue's proposal
- [ ] After merge, run `review-loop` on this branch in docs/protocol scope to confirm rule-hardening (#46) and fresh-vs-resumed breakdown (#13) behave as expected
- [ ] Confirm linked issues are closed with cross-reference comments