### PR TITLE
chore(skills): bump harness 0.14.0 + review-loop 1.4.0 (retro-rules adoption)

### DIFF
--- a/plugins/harness-engineering-skills/skills/harness/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness
-version: 0.13.0
+version: 0.14.0
 description: |
   Cybernetics-based multi-agent orchestration for complex tasks. Coordinates a
   Planner → Generator → Evaluator → Retro pipeline with clean-context sub-agents,

--- a/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-loop
-version: 1.3.0
+version: 1.4.0
 description: |
   Cross-LLM iterative code review loop. Spawns a peer reviewer (Codex, Claude, or Gemini CLI)
   to review code changes, then iterates until both agents agree on the final code state.


### PR DESCRIPTION
## Summary

Bump minor versions on both skills to reflect the rule-hardening and
additive-schema changes landed via #5.

| Skill | Before | After | Rationale |
|---|---|---|---|
| `harness` | 0.13.0 | **0.14.0** | New protocol rules: Generator Will Not exception (#43), sibling-scan (#44), Wiring Checkpoint pattern (#3), mandatory `fault_path_probe` Tier 2 field (#14) |
| `review-loop` | 1.3.0 | **1.4.0** | Fresh-final as load-bearing for docs/protocol scope (#46), Round Breakdown section in summary.md (#13), monorepo scope containment (#30) |

## Why minor (not patch)

Patch reserved for bugfix / typo. These are **rule additions** that change how the Generator and Evaluator agents behave — and new mandatory fields in `evaluation.md` Tier 2. Downstream consumers (other repos referencing this plugin) should be able to tell "does my `harness` know about `fault_path_probe`?" by reading the version.

## Why not major

All additions are **backward-compatible** for consumers that ignore unknown fields. Existing evaluation.md files without `fault_path_probe` are not rejected; they simply don't benefit from the new check until a fresh Evaluator session regenerates them.

## plugin.json

Left at 1.0.0 — plugin-level meta tracks the repo shape (which skills are bundled and how), not the skills' internal evolution. Next plugin-level bump would be e.g. if we add/remove a skill or restructure the plugin directory.

## Test plan
- [ ] `claude plugin list | grep harness-engineering-skills` shows 1.0.0 (unchanged)
- [ ] Invoking `harness` skill, SKILL.md loads with version `0.14.0` in frontmatter
- [ ] Invoking `review-loop` skill, SKILL.md loads with version `1.4.0` in frontmatter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Harness skill version to 0.14.0
  * Updated Review Loop skill version to 1.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->