### PR TITLE
Add harness convention scout and doc-gap workflow

### DIFF
--- a/docs/adr/0000-TEMPLATE.md
+++ b/docs/adr/0000-TEMPLATE.md
@@ -1,0 +1,47 @@
+# Title
+
+## Status
+
+Proposed
+
+## Date
+
+YYYY-MM-DD
+
+## Deciders
+
+- Name or role
+
+## Context
+
+Describe the forces, constraints, and problem that require a decision.
+
+## Decision Drivers
+
+- Driver
+
+## Options Considered
+
+- Option
+
+## Decision
+
+Record the selected option and the reason it was chosen.
+
+## Consequences
+
+- Positive:
+- Negative:
+- Neutral:
+
+## Validation
+
+Describe how the decision will be checked in implementation or operation.
+
+## Related ADRs
+
+- None
+
+## External References
+
+- None

--- a/docs/adr/0001-convention-scout-and-host-repo-doc-gap.md
+++ b/docs/adr/0001-convention-scout-and-host-repo-doc-gap.md
@@ -1,0 +1,105 @@
+# Convention Scout and Host Repository Documentation Gap
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-24
+
+## Deciders
+
+- Harness maintainers
+
+## Context
+
+Harness planning turns user intent into checkpoint acceptance criteria. Those
+criteria are only as precise as the repository conventions available to the
+Planner. When a host repository lacks clear verification or testing guidance,
+the Planner currently has no structured way to distinguish weak wording from
+missing source material.
+
+That ambiguity causes two downstream problems. First, the Spec Evaluator can
+label criteria as vague without saying whether the problem is the criterion
+text or absent host documentation. Second, Retro can observe repeated gaps but
+cannot turn them into issue-ready repository improvements.
+
+Harness will add a read-only `harness-convention-scout` sub-agent that runs at
+planning time, emits a `host-conventions-card.md`, and lets planning,
+evaluation, and retro stages share one documented view of host-repository
+convention evidence.
+
+The canonical Card schema and probe priority list are maintained in
+[protocol-quick-ref.md](../../plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md);
+see the `host-conventions-card.md` section in that file. This ADR records the
+rationale for the Scout/Card/MADR-draft pattern and intentionally does not
+duplicate that tier list.
+
+## Decision Drivers
+
+- Acceptance criteria should be grounded in host-repository evidence when that
+  evidence exists.
+- Missing repository documentation should be attributed explicitly rather than
+  silently converted into vague checkpoint wording.
+- Retro findings should produce issue-ready improvements without prescribing a
+  host repository's exact testing strategy.
+- The Card format should have one canonical definition to avoid drift between
+  agent prompts, protocol docs, and ADRs.
+- The probe order should prefer high-authority documentation before inferred
+  executable signals, because authority decays while implementation specificity
+  increases.
+
+## Options Considered
+
+- Keep Planner-only convention discovery.
+- Add Scout output as free-form prose.
+- Add Scout output as a structured Card consumed by Planner, Spec Evaluator,
+  and Retro.
+
+## Decision
+
+Use a dedicated read-only `harness-convention-scout` sub-agent during planning.
+The Scout writes a structured `host-conventions-card.md` artifact. The Planner
+uses the Card when drafting acceptance criteria, the Spec Evaluator uses it to
+attribute vague criteria, and Retro uses it to produce issue-ready Host Repo
+Documentation Gap findings.
+
+When the host repository has an ADR culture, full-gap findings may be drafted
+as MADR-style issue bodies. When no ADR culture exists, Retro emits a plain gap
+report with a soft suggestion to adopt ADRs. Drift between documented
+conventions and executable checks is always high priority.
+
+## Consequences
+
+- Positive: Planner and evaluator behavior becomes traceable to concrete
+  repository evidence.
+- Positive: Repeated documentation gaps become actionable issue bodies instead
+  of implicit human cleanup work.
+- Positive: The Card schema can evolve independently while consumers reference
+  the same canonical source.
+- Negative: Planning gains another asynchronous artifact and a timeout path
+  that consumers must handle.
+- Neutral: Harness defines its own ADR convention with this first ADR and a
+  reusable template.
+
+## Validation
+
+- The Harness protocol quick reference contains the canonical
+  `host-conventions-card.md` schema and probe priority list.
+- The Scout agent references that canonical schema instead of redefining it.
+- Planning protocol, checkpoint definition guidance, Spec Evaluator, and Retro
+  each consume the Card only through the documented artifact contract.
+- ADR-0001 keeps the rationale separate from the canonical Card definition to
+  prevent three-way drift.
+
+## Related ADRs
+
+- None
+
+## External References
+
+- [MADR: Markdown Architectural Decision Records](https://adr.github.io/madr/)
+- [Use Markdown Architectural Decision Records](https://adr.github.io/madr/decisions/0000-use-markdown-architectural-decision-records.html)
+- [Claude Code subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents)
+- [Claude Code Agent Skills](https://docs.claude.com/en/docs/claude-code/skills)

--- a/docs/adr/0001-convention-scout-and-host-repo-doc-gap.md
+++ b/docs/adr/0001-convention-scout-and-host-repo-doc-gap.md
@@ -85,13 +85,17 @@ conventions and executable checks is always high priority.
 
 ## Validation
 
-- The Harness protocol quick reference contains the canonical
-  `host-conventions-card.md` schema and probe priority list.
-- The Scout agent references that canonical schema instead of redefining it.
-- Planning protocol, checkpoint definition guidance, Spec Evaluator, and Retro
-  each consume the Card only through the documented artifact contract.
-- ADR-0001 keeps the rationale separate from the canonical Card definition to
-  prevent three-way drift.
+- Specs cite the Card when it is available and move partial, full, or unavailable
+  convention gaps into Open Questions instead of inventing verification rules.
+- Spec Evaluator attributes VAGUE criteria with `reason: criterion-wording` or
+  `reason: tier-absence` only when `scout_status: complete`; otherwise it
+  records Card unavailability.
+- Retro emits Issue-ready Host Repo Documentation Gap items from the Card
+  decision table, including MADR drafts when ADR culture is detected and plain
+  reports when it is not.
+- Future Card schema or P0-P9 changes update the canonical
+  `protocol-quick-ref.md` section first; consumers remain path references or
+  implementation checklists, not competing definitions.
 
 ## Related ADRs
 

--- a/plugins/harness-engineering-skills/agents/harness-convention-scout.md
+++ b/plugins/harness-engineering-skills/agents/harness-convention-scout.md
@@ -61,6 +61,10 @@ what the repository intends; later tiers show what appears to run.
 
 Keyword match rule: `test|testing|verify|qa`
 
+Apply the keyword match rule to P3-P9 path names, filenames, and the first
+200 lines of text content, case-insensitively. Treat it as a discovery hint,
+not proof of a documented convention.
+
 ## Key Actions
 
 1. Locate `.harness/<task-id>/host-conventions-card.md` as the output artifact

--- a/plugins/harness-engineering-skills/agents/harness-convention-scout.md
+++ b/plugins/harness-engineering-skills/agents/harness-convention-scout.md
@@ -1,0 +1,104 @@
+---
+name: harness-convention-scout
+description: "Harness Convention Scout — dispatched by Planner at brainstorm start to scan host-repo convention evidence and write host-conventions-card.md."
+model: inherit
+---
+
+# Convention Scout Agent
+
+## Identity
+
+Read-only repository convention scout focused on discovering how the host repo
+documents verification, quality, and review practice before Harness specs are
+drafted.
+
+## Behavioral Mindset
+
+Prefer evidence over inference. High-authority documentation should guide the
+Card when it exists; executable artifacts are useful only as lower-authority
+signals. When evidence is thin or contradictory, report the gap directly
+instead of filling it with assumptions.
+
+## Principles
+
+1. **Reference, do not restate** — the canonical Card schema and P0-P9 probe
+   tiers live in `plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md`.
+2. **Read-only evidence** — scan and quote; never change host-repo files.
+3. **Tool agnostic** — record convention signals without assuming a specific
+   framework, command runner, or repository layout.
+4. **Attribution over blame** — distinguish missing repository guidance from
+   weak spec wording.
+5. **Drift is a finding** — documented guidance that disagrees with automation
+   is surfaced as `docs_vs_ci_drift: detected`.
+
+## Focus Areas
+
+- High-authority repository decision and contributor guidance.
+- Verification, quality, and review docs.
+- Automation and executable signals that confirm or contradict docs.
+- Issue-ready evidence Retro can cite without re-scanning the host repo.
+
+## Probe Order
+
+Use the canonical P0-P9 definitions from `protocol-quick-ref.md`; this table is
+a working checklist, not a replacement for that source of truth.
+
+Why this order: authority decays while specificity increases. Early tiers say
+what the repository intends; later tiers show what appears to run.
+
+| Tier | Scout action |
+|------|--------------|
+| P0 | Check for decision-record culture and verification-related decisions. |
+| P1 | Check repository-specific assistant, automation, or skill instructions. |
+| P2 | Check always-on contributor documentation. |
+| P3 | Check dedicated verification, quality, or review documentation. |
+| P4 | Check development workflow documentation. |
+| P5 | Check human-facing task templates. |
+| P6 | Check declared project command catalogs. |
+| P7 | Check repository helper scripts. |
+| P8 | Check continuous integration or automation reality. |
+| P9 | Check inferred executable artifacts. |
+
+Keyword match rule: `test|testing|verify|qa`
+
+## Key Actions
+
+1. Locate `.harness/<task-id>/host-conventions-card.md` as the output artifact
+   requested by the Planner prompt.
+2. Read `protocol-quick-ref.md` before writing the Card. Use its
+   `host-conventions-card.md` section for frontmatter, body sections, enums,
+   and canonical tier definitions.
+3. Probe P0 through P9 in ascending order. For each tier, record FOUND or
+   NOT_FOUND, a path or N/A, and a short sanitized extract.
+4. Detect contradictions across tiers. In particular, compare always-on or
+   dedicated docs against automation reality; if they disagree, set
+   `docs_vs_ci_drift: detected` and describe the conflict.
+5. Classify `host_repo_doc_gap` using the canonical rules in
+   `protocol-quick-ref.md`.
+6. Set `adr_culture_detected` from P0 evidence only.
+7. Write the Card even on partial or failed scans when possible. Use
+   `scout_status: partial` or `scout_status: failed` and record what could not
+   be completed.
+
+## Outputs
+
+- `.harness/<task-id>/host-conventions-card.md`, formatted per
+  `protocol-quick-ref.md`.
+
+## Boundaries
+
+**Will:**
+- Perform a read-only scan of repository files.
+- Quote short, sanitized extracts as evidence.
+- Surface missing documentation and drift without assigning blame.
+
+**Will Not:**
+- Modify repository files; this agent does not modify source, docs, or config.
+- Invent conventions that are not supported by repository evidence; this agent does not invent missing policy.
+- Prescribe the host repository's verification strategy; this agent does not prescribe how teams should test.
+- Write Harness specs, evaluate checkpoints, or run Retro.
+
+---
+
+Task-specific context (task id, output path, and repository root) is provided
+in the prompt when this agent is spawned.

--- a/plugins/harness-engineering-skills/agents/harness-retro.md
+++ b/plugins/harness-engineering-skills/agents/harness-retro.md
@@ -30,7 +30,7 @@ Be analytical and evidence-based. Look for patterns, not individual incidents. D
 - Frequency analysis against historical retro records
 - Rule/principle upgrade proposals with drafted CLAUDE.md text
 - Skill defect identification (issues in harness protocols, not project code)
-- Host Repo Documentation Gap findings from host-conventions-card evidence
+- Host Repo Documentation Gap findings from host-conventions-card.md evidence
 
 ## Key Actions
 
@@ -41,7 +41,7 @@ Be analytical and evidence-based. Look for patterns, not individual incidents. D
    - Consume `.harness/<task-id>/host-conventions-card.md` only when
      `scout_status: complete`; otherwise treat the Card as unavailable and
      classify as P0-P5 absent for gap analysis.
-   - Mark these findings with `source: host-conventions-card`.
+   - Mark these findings with `source: host-conventions-card.md`.
    - Apply this decision table:
 
      | Card condition | Retro category outcome |
@@ -103,7 +103,7 @@ For Host Repo Documentation Gap findings, include these additional fields in
 the issue-ready item:
 
 ```markdown
-- **Source**: source: host-conventions-card
+- **Source**: source: host-conventions-card.md
 - **Checkpoint evaluation**: <path to CP evaluation that surfaced the gap, or N/A>
 ```
 

--- a/plugins/harness-engineering-skills/agents/harness-retro.md
+++ b/plugins/harness-engineering-skills/agents/harness-retro.md
@@ -50,6 +50,19 @@ Be analytical and evidence-based. Look for patterns, not individual incidents. D
      | `host_repo_doc_gap: full` + `adr_culture_detected: false` | Host Repo Documentation Gap -> plain report + soft ADR suggestion |
      | `docs_vs_ci_drift: detected` | Host Repo Documentation Gap -> plain report or MADR draft per culture; priority: high |
      | `host_repo_doc_gap: partial` | Host Repo Documentation Gap -> Monitoring |
+   - When the outcome is a MADR draft but the host repo lacks
+     `docs/adr/0000-TEMPLATE.md`, fall back to this standard MADR-core
+     skeleton:
+     - Status
+     - Context
+     - Decision Drivers
+     - Options Considered
+     - Decision
+     - Consequences
+   - Scope note: this six-heading MADR-core fallback is a MADR subset. A host
+     repo's `docs/adr/0000-TEMPLATE.md` may be an eleven-heading template
+     superset with repo-specific extensions; prefer the host template when it
+     exists.
 
 5. Cross-reference with historical frequency (is this new or recurring?)
 6. Detect rule conflicts from output-summary.md "Rule Conflict Notes"
@@ -86,17 +99,33 @@ The retro.md must structure rule proposals and skill defects so the Orchestrator
 
 Set `Issue-ready: true` for items with status=Proposed and severity ≥ medium. The Orchestrator will create GitHub issues for these automatically.
 
+For Host Repo Documentation Gap findings, include these additional fields in
+the issue-ready item:
+
+```markdown
+- **Source**: source: host-conventions-card
+- **Checkpoint evaluation**: <path to CP evaluation that surfaced the gap, or N/A>
+```
+
+If the finding came directly from the Card rather than a checkpoint
+evaluation, set `Checkpoint evaluation: N/A`. If a checkpoint evaluation
+surfaced the gap, reference that CP evaluation path so the issue body carries
+the original evidence trail.
+
 ## Boundaries
 
 **Will:**
 - Analyze task execution patterns
 - Draft concrete rule text for CLAUDE.md
+- Draft Issue bodies for `Issue-ready: true` findings
 - Update the retro index with frequency data
 - Flag skill defects for human review
 
 **Will Not:**
 - Modify CLAUDE.md directly (human must approve)
 - Modify SKILL.md or protocol files (constitutional layer)
+- File GitHub issues automatically; Retro drafts the Issue body but does not file it.
+- Prescribe the host repo's testing strategy; Retro reports documentation gaps and drafts options only.
 - Re-evaluate code or re-run tests
 - Make judgments about code quality (that's the Evaluator's job)
 

--- a/plugins/harness-engineering-skills/agents/harness-retro.md
+++ b/plugins/harness-engineering-skills/agents/harness-retro.md
@@ -30,22 +30,37 @@ Be analytical and evidence-based. Look for patterns, not individual incidents. D
 - Frequency analysis against historical retro records
 - Rule/principle upgrade proposals with drafted CLAUDE.md text
 - Skill defect identification (issues in harness protocols, not project code)
+- Host Repo Documentation Gap findings from host-conventions-card evidence
 
 ## Key Actions
 
 1. Read retro-input.md (pre-assembled task metrics and checkpoint summaries)
 2. Read recent historical retros from .harness/retro/
 3. Identify error patterns — categorize each with a tag
-4. Cross-reference with historical frequency (is this new or recurring?)
-5. Detect rule conflicts from output-summary.md "Rule Conflict Notes"
-6. Classify each finding: project CLAUDE.md vs skill defect
-7. Draft recommendations:
+4. Identify Host Repo Documentation Gap findings:
+   - Consume `.harness/<task-id>/host-conventions-card.md` only when
+     `scout_status: complete`; otherwise treat the Card as unavailable and
+     classify as P0-P5 absent for gap analysis.
+   - Mark these findings with `source: host-conventions-card`.
+   - Apply this decision table:
+
+     | Card condition | Retro category outcome |
+     |---|---|
+     | `host_repo_doc_gap: full` + `adr_culture_detected: true` | Host Repo Documentation Gap -> MADR draft |
+     | `host_repo_doc_gap: full` + `adr_culture_detected: false` | Host Repo Documentation Gap -> plain report + soft ADR suggestion |
+     | `docs_vs_ci_drift: detected` | Host Repo Documentation Gap -> plain report or MADR draft per culture; priority: high |
+     | `host_repo_doc_gap: partial` | Host Repo Documentation Gap -> Monitoring |
+
+5. Cross-reference with historical frequency (is this new or recurring?)
+6. Detect rule conflicts from output-summary.md "Rule Conflict Notes"
+7. Classify each finding: project CLAUDE.md vs skill defect
+8. Draft recommendations:
    - High frequency (3+ in last 10 tasks) → draft exact CLAUDE.md rule text
    - Low frequency → add to monitoring
    - Rule conflicts → draft clarification text for CLAUDE.md
    - Skill defects → flag in Skill Defect Log
-8. Update retro/index.md frequency table
-9. Write retro.md per protocol format
+9. Update retro/index.md frequency table
+10. Write retro.md per protocol format
 
 ## Outputs
 

--- a/plugins/harness-engineering-skills/agents/harness-retro.md
+++ b/plugins/harness-engineering-skills/agents/harness-retro.md
@@ -42,7 +42,10 @@ Be analytical and evidence-based. Look for patterns, not individual incidents. D
      `scout_status: complete`; otherwise treat the Card as unavailable and
      classify as P0-P5 absent for gap analysis.
    - Mark these findings with `source: host-conventions-card.md`.
-   - Apply this decision table:
+   - If the Card is unavailable or `scout_status != complete`, emit a plain
+     report with a soft ADR suggestion and treat `adr_culture_detected` as
+     false by default.
+   - Apply this decision table when the Card is complete:
 
      | Card condition | Retro category outcome |
      |---|---|

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -42,6 +42,21 @@ For each checkpoint evaluate:
 2. **Acceptance criteria testability** — can each criterion be verified with a concrete test?
    - BAD: "Authentication works correctly"
    - GOOD: "POST /api/auth/login with valid credentials returns 200 + JWT; invalid credentials return 401"
+   - If `.harness/<task-id>/host-conventions-card.md` exists with
+     `scout_status: complete`, use the Host Conventions Card as an input to
+     the TESTABLE / VAGUE judgment.
+   - When marking a criterion VAGUE, include one attribution:
+     - `VAGUE - reason: criterion-wording`: the criterion is subjective or
+       underspecified even though the relevant convention is documented.
+       Suggested fix wording: rewrite the criterion into an observable command,
+       assertion, screenshot, response, or artifact check.
+     - `VAGUE - reason: tier-absence`: the criterion depends on a host-repo
+       convention that is absent from the Card's P0-P5 evidence. Suggested fix
+       wording: move the convention question to the spec's Open Questions or
+       cite a concrete lower-tier signal explicitly.
+   - If the Card is missing or `scout_status` is anything other than
+     `complete`, record `Card unavailable - attribution deferred`; do not use
+     Card-based tier attribution for this round.
 3. **Dependencies** — are inter-checkpoint dependencies explicit? Is the ordering correct?
 4. **Type accuracy** — is `frontend | backend | fullstack | infrastructure` correctly assigned?
 5. **Files of interest** — are the affected files listed? Are any missing?

--- a/plugins/harness-engineering-skills/skills/harness/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/harness/SKILL.md
@@ -16,7 +16,7 @@ description: |
 
 # Harness — Multi-Agent Orchestration
 
-Orchestrate complex tasks through Planning → Generation ��� Evaluation → Retro.
+Orchestrate complex tasks through Planning -> Generation -> Evaluation -> Retro.
 Fresh sub-agents per checkpoint prevent drift. Retro accumulates learning across tasks.
 
 ## Recommended Workflow
@@ -41,7 +41,7 @@ Session 2 (Codex)       → Execute checkpoints → Evaluate → E2E → Full-ve
 5. For Codex-hosted execution: `claude` CLI on PATH for sub-agent dispatch and review-loop
 
 Verify (Claude Code): `claude plugin list | grep superpowers`
-Verify (review roles): `ls ~/.claude/plugins/**/plugins/harness-engineering-skills/agents/harness-*.md 2>/dev/null || ls plugins/harness-engineering-skills/agents/harness-*.md` (plugin-bundled) and `ls ~/.claude/agents/harness-*.md 2>/dev/null` (optional user override)
+Verify (review roles): `{ find ~/.claude/plugins -path '*/plugins/harness-engineering-skills/agents/harness-*.md' -type f 2>/dev/null; ls plugins/harness-engineering-skills/agents/harness-*.md 2>/dev/null; ls ~/.claude/agents/harness-*.md 2>/dev/null; } | sort -u`
 Verify (Codex): `codex --version && claude --version`
 
 ## Engine Script
@@ -101,36 +101,36 @@ Orchestrator (you, the Main Agent — Claude Code or Codex)
 
 ```
 .harness/
-├── config.json                         # Project config (git-tracked)
-├── <task-id>/                          # Per-task (gitignored)
-��   ├── spec.md
-│   ├── git-state.json
-│   ├── spec-review/
-│   │   ├��─ round-N-spec-review.md
-│   │   ├── round-N-planner-response.md
-│   │   └─��� status.md
-│   ├── checkpoints/
-│   │   └── NN/
-│   │       ├── context.md
-│   │       ├── iter-N/
-���   │       │   ├── output-summary.md
-│   │       │   ├── evaluation.md
-│   │       │   ├── evaluator-session-id.txt
-│   │       │   └── evidence/
-│   │       └── status.md
-│   ├── e2e/
-│   │   ├── iter-N/ {context.md, e2e-report.md, evidence/}
-│   ���   └── status.md
-│   ├── full-verify/
-│   │   ├── discovery.md
-│   ��   ├── iter-N/
-│   │   │   ├── verification-report.md
-│   │   │   └── evidence/
-│   │   └── status.md
-│   └── retro-input.md
-└── retro/                              # Persistent (git-tracked)
-    ├���─ index.md
-    └── <date>-<task-id>.md
+|-- config.json                         # Project config (git-tracked)
+|-- <task-id>/                          # Per-task (gitignored)
+|   |-- spec.md
+|   |-- git-state.json
+|   |-- spec-review/
+|   |   |-- round-N-spec-review.md
+|   |   |-- round-N-planner-response.md
+|   |   `-- status.md
+|   |-- checkpoints/
+|   |   `-- NN/
+|   |       |-- context.md
+|   |       |-- iter-N/
+|   |       |   |-- output-summary.md
+|   |       |   |-- evaluation.md
+|   |       |   |-- evaluator-session-id.txt
+|   |       |   `-- evidence/
+|   |       `-- status.md
+|   |-- e2e/
+|   |   |-- iter-N/ {context.md, e2e-report.md, evidence/}
+|   |   `-- status.md
+|   |-- full-verify/
+|   |   |-- discovery.md
+|   |   |-- iter-N/
+|   |   |   |-- verification-report.md
+|   |   |   `-- evidence/
+|   |   `-- status.md
+|   `-- retro-input.md
+`-- retro/                              # Persistent (git-tracked)
+    |-- index.md
+    `-- <date>-<task-id>.md
 ```
 
 Gitignore entries are auto-added by `$ENGINE init`.

--- a/plugins/harness-engineering-skills/skills/harness/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/harness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness
-version: 0.14.0
+version: 0.15.0
 description: |
   Cybernetics-based multi-agent orchestration for complex tasks. Coordinates a
   Planner → Generator → Evaluator → Retro pipeline with clean-context sub-agents,
@@ -35,7 +35,7 @@ Session 2 (Codex)       → Execute checkpoints → Evaluate → E2E → Full-ve
 ## Prerequisites
 
 1. `superpowers` plugin installed (Claude Code): Generator preloads TDD, verification, debugging skills
-2. Reviewer role definitions: `harness-spec-evaluator.md`, `harness-generator.md`, `harness-evaluator.md`, `harness-retro.md` — ship with this plugin at `plugins/harness-engineering-skills/agents/`; user overrides may live at `~/.claude/agents/harness-*.md`
+2. Reviewer role definitions: `harness-convention-scout.md`, `harness-spec-evaluator.md`, `harness-generator.md`, `harness-evaluator.md`, `harness-retro.md` — ship with this plugin at `plugins/harness-engineering-skills/agents/`; user overrides may live at `~/.claude/agents/harness-*.md`
 3. `python3` on PATH (engine JSON operations)
 4. `git` repository initialized
 5. For Codex-hosted execution: `claude` CLI on PATH for sub-agent dispatch and review-loop
@@ -80,6 +80,7 @@ Read config: `$ENGINE read-config [--max-spec-rounds N] [--max-eval-rounds N] ..
 ```
 Orchestrator (you, the Main Agent — Claude Code or Codex)
 ├── Planning Phase     → YOU are the Planner (direct user interaction)
+│   ├── harness-convention-scout → sub-agent, host-repo convention discovery + Card
 │   ↕ spec-review/     → iterate with Spec Evaluator on checkpoint quality
 ├── Spec Evaluator     → sub-agent, architecture + feasibility
 ├── Generator          → sub-agent (or local in Codex), TDD skill preloaded

--- a/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
@@ -112,7 +112,7 @@ Each criterion must be verifiable through concrete evidence.
 - [ ] useScreenPadding() returns { paddingHorizontal: number }
 - [ ] post-detail.tsx applies padding via inline style
 - [ ] tsc --noEmit passes with zero errors
-- [ ] existing jest tests pass (npm test)
+- [ ] existing project tests pass (project test command)
 ```
 
 ### Bad Criteria (vague, untestable)

--- a/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/checkpoint-definition.md
@@ -280,6 +280,19 @@ The Planner in Session 1 is responsible for:
 3. **Labeling** — mark each checkpoint with Type and Effort estimate
 4. **Writing criteria** — produce testable acceptance criteria (Spec Evaluator checks TESTABLE|VAGUE)
 
+### Host Conventions Card Use
+
+When `.harness/<task-id>/host-conventions-card.md` is available, the Planner
+should cite the Host Conventions Card in the spec's Technical Approach and use
+its evidence when writing acceptance criteria. Criteria should reference the
+repo convention source when the Card found one, rather than implying a
+convention without attribution.
+
+If Scout surfaces ambiguity, such as `host_repo_doc_gap: partial|full`, or the
+Card is unavailable because `scout_status != complete`, the Planner should
+funnel that ambiguity into the spec's Open Questions instead of encoding it as
+a vague checkpoint criterion.
+
 The Planner does **not**:
 
 - Specify implementation details (Generator's job)

--- a/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
@@ -6,7 +6,7 @@ Use this reference when Codex is the orchestrator. The pipeline (Planning → Ch
 
 - Codex acts as the Orchestrator and local implementer (Generator role within checkpoints).
 - `harness-engine.sh` remains the single source of truth for task state, checkpoints, and phase gates — same engine, same commands, same phase machine.
-- Sub-agent roles (Spec Evaluator, Evaluator, Retro) are dispatched via `claude-agent-invoke.sh` to a Claude CLI process. Any CLI that accepts a prompt and returns structured output can fill these roles.
+- Sub-agent roles (Spec Evaluator, Convention Scout, Evaluator, Retro) are dispatched via `claude-agent-invoke.sh` to a Claude CLI process. Any CLI that accepts a prompt and returns structured output can fill these roles.
 - `review-loop` can use any available peer (`codex`, `claude`, or `gemini`) — the choice is a config option, not an architectural constraint.
 
 > **Symmetry**: The role assignments are interchangeable. Just as Codex can host with Claude sub-agents, Claude Code can host with Codex as the review-loop peer. This document covers the Codex-as-host configuration.
@@ -39,7 +39,10 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
 2. Write `.harness/<task-id>/spec.md` in the normal Harness format. **After this step,
    the remainder of planning is autonomous** — see the "Post-Brainstorming Autonomy"
    section in [planning-protocol.md](planning-protocol.md).
-3. For each spec-review round, invoke Claude as the spec reviewer (fresh each round):
+3. When planning needs host-repo convention discovery, invoke the Scout agent
+   with `--agent harness-convention-scout`; it writes
+   `.harness/<task-id>/host-conventions-card.md` for Planner consumption.
+4. For each spec-review round, invoke Claude as the spec reviewer (fresh each round):
 
 ```bash
 "$CLAUDE_AGENT" \
@@ -48,7 +51,7 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
   --output-file ".harness/$TASK_ID/spec-review/round-${ROUND}-spec-review.md"
 ```
 
-4. Apply accepted spec changes locally in Codex and write `round-N-planner-response.md`
+5. Apply accepted spec changes locally in Codex and write `round-N-planner-response.md`
    documenting accepted/rejected concerns with rationale. Repeat autonomously until
    `approve` verdict or `max_spec_rounds` is exhausted. Escalate to the user only
    in the scenarios enumerated in `planning-protocol.md`'s `Post-Brainstorming

--- a/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
@@ -36,13 +36,17 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
 
 1. Clarify requirements directly with the user.
    - If a dedicated brainstorming skill is unavailable in Codex, do the questioning and design synthesis manually.
-2. Write `.harness/<task-id>/spec.md` in the normal Harness format. **After this step,
+2. At brainstorm start, fork the Scout agent with `--agent
+   harness-convention-scout`; it writes
+   `.harness/<task-id>/host-conventions-card.md` for Planner consumption.
+3. At spec drafting start, strict-block for the Scout result using the same
+   3-minute / 180-second timeout defined in [planning-protocol.md](planning-protocol.md).
+   On timeout, crash, or `scout_status != complete`, proceed and record
+   `Host Conventions Card: unavailable`.
+4. Write `.harness/<task-id>/spec.md` in the normal Harness format. **After this step,
    the remainder of planning is autonomous** — see the "Post-Brainstorming Autonomy"
    section in [planning-protocol.md](planning-protocol.md).
-3. When planning needs host-repo convention discovery, invoke the Scout agent
-   with `--agent harness-convention-scout`; it writes
-   `.harness/<task-id>/host-conventions-card.md` for Planner consumption.
-4. For each spec-review round, invoke Claude as the spec reviewer (fresh each round):
+5. For each spec-review round, invoke Claude as the spec reviewer (fresh each round):
 
 ```bash
 "$CLAUDE_AGENT" \
@@ -51,7 +55,7 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
   --output-file ".harness/$TASK_ID/spec-review/round-${ROUND}-spec-review.md"
 ```
 
-5. Apply accepted spec changes locally in Codex and write `round-N-planner-response.md`
+6. Apply accepted spec changes locally in Codex and write `round-N-planner-response.md`
    documenting accepted/rejected concerns with rationale. Repeat autonomously until
    `approve` verdict or `max_spec_rounds` is exhausted. Escalate to the user only
    in the scenarios enumerated in `planning-protocol.md`'s `Post-Brainstorming

--- a/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
@@ -55,6 +55,10 @@ Everything else is autonomous. Record any remaining ambiguities in the spec's
 1. Receive task description from user
 
 2. Clarify requirements:
+   → Assign the task id early, then fork the Convention Scout in parallel with
+     brainstorming so it can scan while the user conversation continues:
+     - Claude Code: `Agent(subagent_type: "harness-convention-scout", prompt: <task id + repo root + output path .harness/<task-id>/host-conventions-card.md>)`
+     - Codex-hosted planning: `claude-agent-invoke.sh --agent harness-convention-scout --prompt-file "$PROMPT_FILE" --output-file ".harness/<task-id>/host-conventions-card.md"`
    → Invoke superpowers:brainstorming for requirements discovery
    → Follow brainstorming's questioning process (explore, clarify, propose approaches,
      present design, get user approval)
@@ -62,6 +66,14 @@ Everything else is autonomous. Record any remaining ambiguities in the spec's
    → Do NOT proceed to brainstorming's "Write design doc" / "Invoke writing-plans" steps
 
 3. Produce spec.md → write to .harness/<task-id>/spec.md  (AUTONOMOUS — no user pause)
+   → Strict-block on the Scout join before drafting the spec, with a 3-minute
+     (180 seconds) timeout at the join point.
+   → If the Card exists and has `scout_status: complete`, read it before
+     writing Technical Approach and acceptance criteria.
+   → If the Scout times out, crashes, writes no Card, or records
+     `scout_status != complete`, proceed without pausing; the spec must record
+     `Host Conventions Card: unavailable`, and Retro treats this as P0-P5
+     absent for gap classification.
    → Convert the approved design into Harness spec format (see protocol-quick-ref.md)
    → Include checkpoints with ### Checkpoint NN: <title> format
    → Set status: draft in YAML frontmatter

--- a/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
@@ -79,7 +79,7 @@ Everything else is autonomous. Record any remaining ambiguities in the spec's
    → Set status: draft in YAML frontmatter
 
 4. Spawn Spec Evaluator sub-agent for spec review  (AUTONOMOUS — no user pause):
-   → Agent(subagent_type: "harness-spec-evaluator", prompt: <spec + codebase context + protocol-quick-ref.md + prior deferred rejections>)
+   → Agent(subagent_type: "harness-spec-evaluator", prompt: <spec + codebase context + protocol-quick-ref.md + host-conventions-card.md when scout_status: complete, or Card unavailable note + prior deferred rejections>)
    → **Prior deferred rejections input** (rounds ≥ 2): include the prior
      `round-(N-1)-planner-response.md`'s Rejected Changes entries whose
      Verification: block is Form B (authority-only). Ask the Evaluator to

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -220,6 +220,111 @@ The `checkpoint_type` field determines the Generator's testing strategy (TDD for
 
 ---
 
+## host-conventions-card.md
+
+Planner-side Convention Scout output. This artifact records what the host
+repository says about its own verification conventions before a spec is
+drafted. It is the single source of truth for Scout, Spec Evaluator, and Retro
+consumers.
+
+```yaml
+---
+task_id: <matches spec>
+scout_run_at: <ISO-8601 timestamp>
+scout_status: complete | partial | failed
+adr_culture_detected: <boolean>
+highest_authority_source: P0 | P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | none
+host_repo_doc_gap: none | partial | full
+docs_vs_ci_drift: none | detected
+---
+```
+
+Canonical probe priority tiers:
+
+| Tier | Authority surface | Scout probe |
+|------|-------------------|-------------|
+| P0 | Architectural decision records | Repository decision records such as ADR or decision-log directories. |
+| P1 | Repository-specific agent or skill instructions | Local assistant, automation, or skill guidance that governs how work is done in this repo. |
+| P2 | Always-on contributor documentation | Root or docs contributor guides that every change author is expected to read. |
+| P3 | Dedicated verification documentation | Testing, verification, quality, or review docs with explicit project practice. |
+| P4 | Development workflow documentation | Process, release, local setup, or maintenance docs that mention verification expectations. |
+| P5 | Human-facing task templates | Issue, pull request, or change templates that ask authors for verification evidence. |
+| P6 | Declared project commands | Manifest, task-runner, or command catalog entries that name verification commands. |
+| P7 | Repository helper scripts | Checked-in helper scripts whose names or help text describe verification behavior. |
+| P8 | Continuous integration reality | CI or automation configuration that runs verification commands. |
+| P9 | Inferred executable behavior | Test directories, fixtures, or executable artifacts that imply practice without documenting it. |
+
+Ordering rationale: authority decays while specificity increases. P0-P3 are
+the clearest documentation surfaces; P8-P9 can prove what runs but cannot by
+themselves explain the repository's intended convention.
+
+Body sections:
+
+- **Per-priority findings**: table with one row per P0-P9 tier. Each row
+  records `status` (`FOUND` or `NOT_FOUND`), `path`, and a short sanitized
+  `extract`.
+- **Contradictions**: any conflict across tiers, especially documented
+  guidance that disagrees with CI reality.
+- **Gap Classification**: rationale for `host_repo_doc_gap` and
+  `docs_vs_ci_drift`.
+- **Evidence for Retro**: issue-ready facts Retro can cite without re-scanning
+  the host repo.
+
+`host_repo_doc_gap` values:
+
+- `none`: P0-P3 contain substantive convention guidance.
+- `partial`: P0-P3 are absent or thin, but P4-P6 contain useful guidance; or
+  P0-P3 exist but only point elsewhere.
+- `full`: P0-P6 are absent or substantively empty, with signal only from
+  P7-P9 or no signal at all.
+
+Minimal filled example:
+
+```markdown
+---
+task_id: example-task
+scout_run_at: 2026-04-24T09:00:00+08:00
+scout_status: complete
+adr_culture_detected: true
+highest_authority_source: P0
+host_repo_doc_gap: partial
+docs_vs_ci_drift: none
+---
+
+## Per-priority findings
+
+| Tier | Status | Path | Extract |
+|------|--------|------|---------|
+| P0 | FOUND | docs/adr/0001-example.md | "Decisions are recorded as ADRs." |
+| P1 | NOT_FOUND | N/A | No repository-specific assistant or skill guidance found. |
+| P2 | FOUND | README.md | "Run the verification command before review." |
+| P3 | NOT_FOUND | N/A | No dedicated verification guide found. |
+| P4 | NOT_FOUND | N/A | No development workflow doc found. |
+| P5 | NOT_FOUND | N/A | No change template with verification prompt found. |
+| P6 | FOUND | manifest file | Verification command is declared. |
+| P7 | NOT_FOUND | N/A | No helper script guidance found. |
+| P8 | FOUND | automation config | Verification command runs on change. |
+| P9 | FOUND | executable artifacts | Verification artifacts are present. |
+
+## Contradictions
+
+None.
+
+## Gap Classification
+
+`host_repo_doc_gap: partial` because high-authority decision guidance exists,
+but dedicated verification documentation is absent. Other valid values are
+`none` when P0-P3 are substantive and `full` when P0-P6 are absent or empty.
+
+## Evidence for Retro
+
+- ADR culture detected from P0.
+- Dedicated verification guide missing at P3.
+- CI drift not detected.
+```
+
+---
+
 ## output-summary.md (per iteration)
 
 ```yaml

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -468,7 +468,7 @@ project_type: node | python | go | make | unknown
 
 Sections:
 - **Detected Check Commands**: table with columns Name | Command | Source (e.g., "package.json scripts.test")
-- **Test Framework**: detected framework name (jest, vitest, pytest, etc.) or "unknown"
+- **Test Framework**: detected test framework name or "unknown"
 - **Coverage Tool**: detected tool (c8, istanbul, coverage.py, etc.) or "none detected"
 
 ---


### PR DESCRIPTION
## Summary

- Adds `harness-convention-scout` for host-repo convention discovery and Card emission.
- Defines `host-conventions-card.md` as the canonical Card schema / P0-P9 reference and wires Planner, Spec Evaluator, and Retro consumers to it.
- Adds the first MADR-style ADR template and ADR-0001 for the Scout/Card/MADR-draft decision.
- Bumps Harness skill to `0.15.0` and documents the new architecture role.

## Validation

- CP01-CP09: all checkpoint evaluator verdicts PASS.
- E2E: `.harness/convention-scout-and-doc-gap/e2e/iter-1/e2e-report.md` verdict PASS with data-flow audit.
- Review-loop: Claude peer review reached consensus after 2 rounds plus fresh-final consensus; accepted fixes committed in `03ceb76`.
- Full verify: skipped by repo config (`skip_full_verify=true`, documentation/package plugin repo with no runtime suite).
- Post-review structural checks: no replacement characters in `SKILL.md`; sibling scans return 0; product-specific token scan passes; version/scout checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added standardized Architecture Decision Record (ADR) template for consistent documentation authoring.

* **New Features**
  * Introduced automated convention discovery that scans repositories for verification and documentation practices, generating structured convention cards.
  * Enhanced documentation gap analysis to identify and report inconsistencies between documented and actual practices.
  * Improved specification evaluation to leverage discovered repository conventions when creating acceptance criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->