### PR TITLE
docs(harness): codify retro rules from issues #30 and #31

### DIFF
--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -604,6 +604,33 @@ against the upstream base branch.
 
 ---
 
+## live-platform-verification
+
+When a checkpoint touches deployment configuration — `fly.toml`, `vercel.json`,
+`vercel.ts`, `.github/workflows/deploy.yml`, Alembic release-command wiring,
+secret manifests, OAuth callback URLs, or any external-platform CLI version
+pin — the Generator MUST execute the deployment-tier verification command set
+against the live platform before marking the checkpoint complete. Local-only
+verification is necessary but not sufficient.
+
+Required evidence in `output-summary.md` for any qualifying checkpoint:
+
+- The triggered deploy run id (preview or production) and a link to its logs.
+- `curl` evidence against the live `/healthz` and `/readyz` (or framework
+  equivalent), captured against the deployed instance, not a local stand-in.
+- `curl` evidence against the live public site URL.
+- For each newly-required production env var, evidence that the code path
+  reading it under the production env flag (for example `NEXUS_ENV=production`)
+  was exercised against the deployed instance, not just a local `pytest`.
+
+The Evaluator MUST reject "local pytest green" as evidence for a deployment
+checkpoint when the deploy-run / live-endpoint evidence is missing. Iteration
+cost without this rule is observed: cg-personal-launch CP07 required 7
+iterations almost entirely on facts only the live platform knows. Source:
+issue #30.
+
+---
+
 ## review-loop-fullverify-coupling
 
 Review-loop and full-verify are coupled gates. When a harness task runs both,
@@ -626,6 +653,16 @@ Rules:
   `asyncio.Queue`, `asyncio.Lock`, `asyncio.Event`, or background tasks at
   import or module scope, the review-loop round must include focused project
   lifespan/startup tests before it can claim convergence. Source: issue #26.
+- `post-PASS runtime re-verification`: if a review-loop session runs after an
+  E2E PASS verdict and any accepted finding modifies runtime code — paths
+  under `app/`, `server/`, deploy workflow files, framework config, or
+  migrations — the harness must run a delta E2E iteration against the new SHA
+  before the task is considered complete. The delta iteration re-verifies the
+  deploy run for the new SHA, re-runs live `/healthz` / `/readyz` and any
+  task-specific live smoke, and re-walks only the cross-checkpoint data-flow
+  boundaries touched by the review-loop diff. Docs-only / test-only /
+  comment-only post-baseline commits are validated through full-verify's
+  normal path and do not trigger re-E2E. Source: issue #31.
 
 The downstream `review-loop` skill must surface these same rule keywords so the
 operator instructions and harness protocol stay mirrored.


### PR DESCRIPTION
## Summary

Triage outcome PR for issues #30 (high) and #31 (medium). Adds the drafted rule text from each issue to `plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md`, matching the repo's existing pattern of "rule text + `Source: issue #N` citation" (see PR #28 which closed #16 / #21 / #24 the same way).

This is the harness-side adoption only. The host-repo mirror (`HARNESS_CONVENTIONS.md` per the issue authors) is a separate cross-repo task.

## Changes

- **New section `## live-platform-verification`** (peer of `## scope-check`): codifies the rule that deployment-touching checkpoints MUST attach live-platform deploy evidence (deploy run id, live `/healthz` / `/readyz` curls, live public-URL curl, prod-env-flag exercise) in `output-summary.md` before completion. Closes #30.
- **New 4th bullet in `## review-loop-fullverify-coupling`** — `post-PASS runtime re-verification`: codifies the rule that if review-loop modifies runtime code (paths under `app/`, `server/`, deploy workflow files, framework config, or migrations) after an E2E PASS verdict, the harness MUST run a delta E2E iteration against the new SHA before declaring the task done. Docs / tests / comments are exempt and validated through full-verify's normal path. Closes #31.

## What's not in this PR

- **Engine code changes.** The Evaluator's "reject local-pytest-as-deployment-evidence" enforcement (#30) and the harness orchestrator's "delta E2E after post-PASS runtime fix" gate (#31) require engine changes. This PR adds the protocol contract; engine enforcement is a follow-up implementation task.
- **Mirror into `review-loop/SKILL.md`.** The existing 3 coupling rules in §review-loop-fullverify-coupling are operator-facing rules consumed by the harness orchestrator, not by the review-loop skill itself; the new rule has the same shape and does not require a SKILL.md change.
- **Deferred issues.** Issues #27 (medium — magnitude-threshold advisory) and #29 (low — commit-count vs TDD-sequence contradiction detector) require Spec Evaluator scanner / engine code changes, not just rule text. Triage commentary posted on each; deferred for engineer implementation. See:
  - https://github.com/stone16/harness-engineering-skills/issues/27#issuecomment-4394076117
  - https://github.com/stone16/harness-engineering-skills/issues/29#issuecomment-4394077485

## Test plan

- [ ] Visual review: `protocol-quick-ref.md` renders cleanly on GitHub; new sections sit between existing sections without breaking the surrounding narrative.
- [ ] Cross-reference check: each new rule cites its source issue with the canonical `Source: issue #N` form used by every other rule in this file.
- [ ] No regression in section anchors: existing references to `§scope-check`, `§review-loop-fullverify-coupling`, `§verification-block`, etc. continue to resolve.
- [ ] Docs-only diff: `git diff --stat main...HEAD` shows exactly one file changed, +37 insertions, 0 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added live-platform-verification rule requiring deployment checkpoints to be validated against live platform with specified evidence documentation (deploy run ID, health checks, URL verification, environment variable evidence)
  * Added post-PASS runtime re-verification rule for review-loop sessions triggered when accepted findings modify runtime-affecting files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->