### PR TITLE
feat(harness): record generator/planner/evaluator host + model in artifacts

### DIFF
--- a/docs/adr/0005-record-generator-and-planner-host-model.md
+++ b/docs/adr/0005-record-generator-and-planner-host-model.md
@@ -1,0 +1,137 @@
+# Record Generator and Planner Host + Model in Harness Artifacts
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-09
+
+## Deciders
+
+- Harness maintainers
+
+## Context
+
+Harness already records `evaluator_host` and `evaluator_session_id` in
+`evaluation.md` frontmatter, which lets a downstream consumer attribute each
+evaluation to a specific AI host (Claude Code, Codex, Gemini CLI, etc.).
+
+The same attribution does **not** exist for the Generator (the agent that
+writes code per checkpoint) or the Planner (the agent that drafts `spec.md`).
+A retrospective analysis attempting to answer questions like "did Codex 5.5 +
+Claude 4.7 raise our one-shot pass rate?" or "which model writes specs that
+need fewer review rounds?" must currently infer host from indirect signals
+(branch name prefixes, ccusage daily token counts, evaluator_host plus
+cross-model assumptions). Each of those proxies has known failure modes.
+
+The gap also makes it impossible to do same-host model-version comparisons
+even on the evaluator side — `evaluator_host: claude-cli` covers Claude Opus
+4.6 and Opus 4.7 alike, so a 6-week dataset that spans the 4.6 → 4.7 cutover
+cannot be cleanly partitioned without resorting to date-based heuristics.
+
+Because each artifact is written by an agent that *knows* which model it is
+running, recording this information at write time is cheap. The value
+compounds across tasks: with the fields in place, future analyses can
+attribute every iter, every spec, and every evaluation to a concrete
+(host, model) pair.
+
+## Decision Drivers
+
+- Attribution should not depend on inference from token-usage logs whose
+  format is owned by a third-party tool.
+- Existing `evaluator_host` is the precedent — Generator, Planner, and
+  Evaluator should be symmetric in what they record.
+- New fields must be **optional** so that older `.harness/` artifacts and
+  existing parsers continue to work unchanged.
+- Field names must be self-explanatory and avoid abbreviations so consumers
+  can grep across artifacts without ambiguity.
+- The cost of recording is one frontmatter line per agent; the cost of *not*
+  recording is permanent loss of attribution data once a task completes.
+
+## Options Considered
+
+- **Status quo** — keep inferring host and model from `evaluator_host` plus
+  ccusage daily logs.
+- **Record only host** — add `generator_host` and `planner_host` fields but
+  skip the model version, leaving "which Opus" or "which gpt-5.x" still
+  ambiguous.
+- **Record host + model + session id** — add a small frontmatter block per
+  agent, mirroring the existing evaluator pattern.
+- **Record host + model + session id + start/end timestamps** — also capture
+  per-iteration wall-clock duration, supporting cost and latency analysis
+  later.
+
+## Decision
+
+Adopt the **host + model + session id + timestamps** option. Specifically:
+
+1. **`output-summary.md`** (per iteration, written by Generator) gains five
+   optional frontmatter fields:
+   - `generator_host` (e.g., `codex-cli`, `claude-code-agent`)
+   - `generator_model` (e.g., `gpt-5.5`, `claude-opus-4-7`)
+   - `generator_session_id`
+   - `generator_started_at` (ISO-8601)
+   - `generator_completed_at` (ISO-8601)
+2. **`spec.md`** (per task, written by Planner) gains three optional
+   frontmatter fields:
+   - `planner_host`
+   - `planner_model`
+   - `planner_session_id`
+3. **`evaluation.md`** (already has `evaluator_host` and
+   `evaluator_session_id`) gains one new optional field for symmetry:
+   - `evaluator_model`
+
+All seven new fields are optional — engine commands and existing parsers
+continue to ignore them. Agents that know their host and model SHOULD
+populate them; agents that cannot determine the value MAY omit the field.
+
+## Consequences
+
+- **Positive**:
+  - Per-iter attribution becomes possible without inference. Analyses like
+    "Generator pass rate by model" become arithmetic instead of guesswork.
+  - Same-host model-version splits (4.6 vs 4.7, 5.4 vs 5.5) become trivial.
+  - Symmetry across Generator / Planner / Evaluator simplifies parsers —
+    one mental model for all three artifact types.
+  - Optional adoption means no migration required for existing
+    `.harness/<task-id>/` directories.
+- **Negative**:
+  - Each agent must know its own host and model. For Claude Code sub-agents,
+    this is exposed via the runtime context. For Codex, the orchestrator
+    injects it via prompt. For other hosts, populating these fields requires
+    upstream changes outside this repo.
+  - Field names are not validated by the engine, so a typo (e.g.,
+    `generator_modle`) would silently fail to attribute. Documentation in
+    `protocol-quick-ref.md` is the only safeguard at v1.
+- **Neutral**:
+  - Old artifacts remain readable. Consumers must handle the optional case
+    (field present, absent, or empty string).
+  - The exact string convention for `*_model` (e.g., `claude-opus-4-7` vs
+    `claude-opus-4-7-20260416`) is left to the writer; documentation
+    recommends the short canonical form to keep grep-friendly.
+
+## Validation
+
+- Run a fresh Harness task end-to-end after the agent prompt updates and
+  confirm `spec.md`, every `output-summary.md`, and every `evaluation.md`
+  contain the new frontmatter fields.
+- Existing tasks under `.harness/<task-id>/` must continue to satisfy the
+  engine's `pass-checkpoint`, `pass-e2e`, `pass-full-verify` gates without
+  modification (backwards-compat check).
+- A minimal parser snippet in this ADR's diff (or a follow-up issue) should
+  demonstrate that the seven new fields can be extracted with a single
+  `grep '^generator_model:'` style invocation per artifact type.
+
+## Related ADRs
+
+- `0003-engine-parser-canonical-shape-contract.md` — engine parser contract;
+  this change adds fields the parser already ignores, so the contract is
+  unchanged.
+
+## External References
+
+- `docs/specs/2026-05-09-harness-value-analysis-design.md` (in the original
+  motivating analysis branch) — drove the realization that Generator and
+  Planner attribution is the limiting factor for retrospective analyses.

--- a/plugins/harness-engineering-skills/agents/harness-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-evaluator.md
@@ -65,6 +65,14 @@ When the checkpoint type is `frontend` or `fullstack`:
 - `evaluation.md` in the checkpoint's iter-N/ directory (format provided in protocol reference in your prompt)
 - `evidence/` directory with screenshots, test output, API responses
 
+When writing `evaluation.md`, populate the optional `evaluator_model`
+field in the YAML frontmatter when you can determine it (see
+`protocol-quick-ref.md` § evaluation.md and ADR 0005). It complements
+the existing `evaluator_host` and `evaluator_session_id` fields and
+lets retrospective analyses split same-host model versions (e.g.,
+Opus 4.6 vs 4.7). Omit the field rather than fabricating a placeholder
+when the value is genuinely unknown.
+
 ## Boundaries
 
 **Will:**

--- a/plugins/harness-engineering-skills/agents/harness-generator.md
+++ b/plugins/harness-engineering-skills/agents/harness-generator.md
@@ -70,6 +70,24 @@ Prioritize correctness and spec compliance above all else. Write code that works
 - Code changes via atomic git commits
 - `output-summary.md` in the checkpoint's iter-N/ directory (format provided in protocol reference in your prompt)
 
+When writing `output-summary.md`, populate the optional generator
+attribution fields in the YAML frontmatter when you can determine them
+(see `protocol-quick-ref.md` § output-summary.md and ADR 0005):
+
+- `generator_host` — your runtime host (e.g., `claude-code-agent`,
+  `codex-cli`)
+- `generator_model` — the model you are running on (e.g.,
+  `claude-opus-4-7`, `gpt-5.5`)
+- `generator_session_id` — your session identifier when available
+- `generator_started_at` — ISO-8601 timestamp captured before the first
+  meaningful action of this iter
+- `generator_completed_at` — ISO-8601 timestamp captured after the last
+  commit but before writing this summary
+
+If a value is genuinely unknown (e.g., the runtime does not expose the
+session id), omit just that field rather than fabricating a placeholder.
+The fields are optional; the engine ignores them.
+
 ## Boundaries
 
 **Will:**

--- a/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md
@@ -77,6 +77,14 @@ Everything else is autonomous. Record any remaining ambiguities in the spec's
    → Convert the approved design into Harness spec format (see protocol-quick-ref.md)
    → Include checkpoints with ### Checkpoint NN: <title> format
    → Set status: draft in YAML frontmatter
+   → Populate the optional planner attribution fields in the YAML
+     frontmatter when known (see protocol-quick-ref.md § spec.md and
+     ADR 0005):
+       planner_host       — your runtime host (e.g., claude-code, codex-cli)
+       planner_model      — the model you are running on (e.g., claude-opus-4-7)
+       planner_session_id — your session identifier, if available
+     Omit any individual field when the value is genuinely unknown rather
+     than fabricating a placeholder. The engine ignores these fields.
 
 4. Spawn Spec Evaluator sub-agent for spec review  (AUTONOMOUS — no user pause):
    → Agent(subagent_type: "harness-spec-evaluator", prompt: <spec + codebase context + protocol-quick-ref.md + host-conventions-card.md when scout_status: complete, or Card unavailable note + prior deferred rejections>)

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -15,10 +15,20 @@ status: draft | reviewing | approved
 branch: <git branch name>
 created: <ISO timestamp>
 updated: <ISO timestamp>
+# Optional planner attribution (see ADR 0005). Populate when host/model
+# is known; omit fields you cannot determine.
+planner_host: <claude-code | claude-cli | codex-cli | gemini-cli | other>
+planner_model: <e.g., claude-opus-4-7, gpt-5.5>
+planner_session_id: <session id from planning host, if available>
 ---
 ```
 
 Sections: Goal, Success Criteria, Checkpoints, Technical Approach, Out of Scope, Open Questions.
+
+The three `planner_*` fields are optional and exist purely for retrospective
+analysis. The engine ignores them; existing specs without them remain
+valid. See `docs/adr/0005-record-generator-and-planner-host-model.md` for
+the rationale.
 
 **Checkpoint heading format (REQUIRED by engine parser):**
 ```markdown
@@ -392,10 +402,22 @@ but dedicated verification documentation is absent. Other valid values are
 task_id: <matches spec>
 checkpoint: <number>
 iteration: <number>
+# Optional generator attribution (see ADR 0005). Populate when host/model
+# is known; omit fields you cannot determine.
+generator_host: <claude-code-agent | claude-cli | codex-cli | gemini-cli | other>
+generator_model: <e.g., gpt-5.5, claude-opus-4-7>
+generator_session_id: <session id from generation host, if available>
+generator_started_at: <ISO-8601 timestamp when this iter began>
+generator_completed_at: <ISO-8601 timestamp when this iter's commits landed>
 ---
 ```
 
 Sections: What Was Done (+ rationale), Files Modified, Git Commits (SHAs + messages), Rule Conflict Notes (empty if none), Notes for Evaluator.
+
+The five `generator_*` fields are optional. The engine ignores them;
+existing summaries without them remain valid. See
+`docs/adr/0005-record-generator-and-planner-host-model.md` for the
+rationale.
 
 ---
 
@@ -410,6 +432,10 @@ verdict: PASS | FAIL | REVIEW
 evaluator_agent: harness-evaluator
 evaluator_host: claude-code-agent | claude-cli | codex-cli | gemini-cli
 evaluator_session_id: <session id from evaluator agent>
+# Optional evaluator model (see ADR 0005). Recorded for symmetry with
+# generator_model and planner_model. Engine ignores; older evaluations
+# without it remain valid.
+evaluator_model: <e.g., claude-opus-4-7, gpt-5.5>
 ---
 ```
 


### PR DESCRIPTION
## Summary

Adds **9 new optional YAML frontmatter fields** across `spec.md`,
`output-summary.md`, and `evaluation.md` so retrospective analyses can
attribute every Harness artifact to a concrete `(host, model)` pair
without inferring from `ccusage` logs or branch-name heuristics. Engine
parsers ignore the new fields; older `.harness/<task-id>/` directories
remain valid without modification.

## Why

`evaluation.md` already records `evaluator_host` and
`evaluator_session_id`. The Generator and Planner agents — which write
just as much output per task — record nothing equivalent. A 6-week
analysis I just ran (60 unique tasks, 280 evaluated iters, 102 retro
observations) showed that meaningful comparisons like "did Codex 5.5 +
Claude 4.7 raise our one-shot pass rate?" or "which model writes specs
that need fewer review rounds?" can only be answered today by chaining
indirect signals: branch-name prefixes (3/100 hits), `ccusage` daily
token logs (different format per vendor), or `evaluator_host` plus
cross-model assumptions (only valid when cross-model is in use). Each
proxy has known failure modes; recording the truth at write time is
cheap and removes the inference layer entirely.

The same gap also makes `evaluator_host` itself coarse-grained —
`claude-cli` covers Opus 4.6 and Opus 4.7 alike, so even the existing
field cannot cleanly partition a dataset that spans the 4.6 → 4.7
cutover. Adding `evaluator_model` for symmetry closes that loop.

See ADR 0005 in this PR for full context, decision drivers, and the
options considered.

## Approach

All new fields are **optional**. Engine commands continue to grep only
the keys they already know about (`status:`, `title:`, `verdict:`, etc.),
so adoption is incremental and existing artifacts need no migration.

| Artifact | New optional fields |
|---|---|
| `spec.md` | `planner_host`, `planner_model`, `planner_session_id` |
| `output-summary.md` | `generator_host`, `generator_model`, `generator_session_id`, `generator_started_at`, `generator_completed_at` |
| `evaluation.md` | `evaluator_model` (extends existing `evaluator_host` / `evaluator_session_id`) |

Files touched:

- `docs/adr/0005-record-generator-and-planner-host-model.md` — new ADR documenting context, decision drivers, options, decision, consequences, validation
- `plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md` — three frontmatter spec sections updated with the new optional fields and a one-line pointer to ADR 0005
- `plugins/harness-engineering-skills/skills/harness/references/planning-protocol.md` — Step 3 in the planning flow now instructs the Planner to populate `planner_*` when known
- `plugins/harness-engineering-skills/agents/harness-generator.md` — Outputs section instructs filling the five `generator_*` fields when determinable, with explicit "omit rather than fabricate" guidance
- `plugins/harness-engineering-skills/agents/harness-evaluator.md` — Outputs section instructs filling `evaluator_model`

Alternatives rejected:

- **Status quo (infer from ccusage logs)** — was the working hypothesis until the dataset hit a wall: only 3/100 spec.md files had a usable host signal (branch-name prefix), and the remaining 97 required date-based inference that conflated 4.6 with 4.7 within a single host.
- **Host only, skip model** — leaves the Opus 4.6 vs 4.7 split unresolved. The marginal cost of adding the model name is one frontmatter line per agent.
- **Add fields and enforce them in the engine** — premature; the engine has no current need for the values, and enforcing field presence would break every existing `.harness/<task-id>/` snapshot. Leave validation as a follow-up if/when consumers depend on the data.

## How I Tested

**Backwards-compat smoke test** — confirmed engine ignores the new fields:

```
$ grep -m1 '^status:' /tmp/spec-with-new-fields.md | sed 's/status:[[:space:]]*//'
approved
$ grep -m1 '^title:' /tmp/spec-with-new-fields.md | sed 's/title:[[:space:]]*//'
smoke-test for new fields
```

**Existing test suite** (`scripts/test-assemble-context.sh`) — passes:

```
$ bash scripts/test-assemble-context.sh
assemble-context parser tests passed
```

This test exercises the engine's spec.md frontmatter parsing on a
synthetic spec, validating that the parser remains tolerant of
arbitrary optional keys.

**Manual review of agent prompt updates** — re-read each modified
agent file end-to-end; the new instructions are appended to the
Outputs section without altering any existing behavior, so the
agents continue to fall back to the unchanged path when the optional
values are not available to them.

## Rollback Plan

1. **Maximum blast radius**: zero. Pure additive frontmatter; no
   engine code paths touched, no schema migrations, no breaking
   changes. A bad merge cannot corrupt existing tasks or block
   future ones.
2. **Time-to-rollback**: under one minute. `git revert` on the merge
   commit reverses every file change atomically; the only "in flight"
   side effect is that agents stop writing the new fields, which is
   a pure no-op for downstream parsers.

## Out of Scope

- **Engine enforcement of the new fields** — fields remain optional.
  If a future consumer (analysis tool, dashboard, CI gate) depends on
  them, that consumer can introduce the validation.
- **Migration of existing `.harness/<task-id>/` artifacts** — only new
  artifacts will carry the fields; old snapshots stay as-is.
- **A reference parser implementation** — the ADR's Validation section
  notes a single-grep approach is sufficient for v1; a richer parser
  ships independently when the first consumer needs it.
- **The retrospective analysis tool that motivated this PR** — already
  built locally on a separate branch; once consumers exist for these
  fields, that tool (or a cleaned-up successor) can ship as its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced artifact protocols with optional attribution fields to track generator, planner, and evaluator metadata (host, model, session ID, and timing).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/harness-engineering-skills/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->