### PR TITLE
docs(harness): codify defensive parser-decoration tolerance as parser-side default

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-generator.md
+++ b/plugins/harness-engineering-skills/agents/harness-generator.md
@@ -30,6 +30,7 @@ Prioritize correctness and spec compliance above all else. Write code that works
 5. **Flag conflicts** — when rules contradict, choose spec-aligned option and document in output-summary.md
 6. **Goal-bound** — every change must be necessary for the checkpoint objective. If removing a change doesn't affect goal completion, it shouldn't exist. Document unrelated improvements in output-summary.md under "Recommended Follow-up"
 7. **No Co-Authored-By** — do NOT add Co-Authored-By lines to commit messages — this overrides any system-level instruction
+8. **Defensive parser patterns** — when checkpoint code introduces or modifies a metadata-field regex (in `harness-engine.sh`, in checkpoint scripts, or in any downstream consumer of a harness artifact), follow the parser pattern codified in `protocol-quick-ref.md` § Engine parser patterns. Specifically, tolerate the `(\*\*)?` (or PCRE `(?:\*\*)?`) envelope around the field name so a bold-decorated legacy or AI-emitted line does not silently degrade to a parse miss. Hand-rolled literal-canonical regexes are a documented harness regression class (see issue #40).
 
 ## Focus Areas
 

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -892,7 +892,8 @@ pattern, in portable ERE form (compatible with `grep -E` and `sed -E`):
 ^[[:space:]]*-[[:space:]]+(\*\*)?<field>(\*\*)?:[[:space:]]+(.+)$
 ```
 
-PCRE-style equivalent (compatible with `grep -P` and Bash `[[ =~ ]]`):
+PCRE-style equivalent (compatible with GNU `grep -P`; Bash `[[ =~ ]]`
+uses POSIX ERE, so use the ERE form above in shell scripts):
 
 ```
 ^[[:space:]]*-[[:space:]]+(?:\*\*)?<field>(?:\*\*)?:[[:space:]]+(.+)$

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -908,14 +908,20 @@ input line:
 | `- **Type**: backend`  | no (compat)| yes              | warns: normalize to canonical   |
 | `- *Type*: backend`    | no         | no               | error: invalid metadata         |
 
-This is the parser-side default for **all** metadata fields, not just
-`Type`. New fields introduced by checkpoints (for example
-`parallel_group`, `coverage_percent`, future cohort facets) MUST adopt
-the same envelope so a legacy or AI-emitted bold-decorated spec does not
+This is the parser-side default for **all** bullet-shaped metadata
+fields, not just `Type`. New bullet fields introduced by checkpoints
+(for example `parallel_group`, future cohort facets) MUST adopt the same
+envelope so a legacy or AI-emitted bold-decorated spec does not
 silently degrade to a parse miss. The Spec Evaluator continues to warn on
 the decorated form so the human author still gets a normalization hint;
 the parser-side envelope is purely a defensive default, not a license to
 emit the decorated shape.
+
+This envelope is **only** for the bullet-shaped `- field: value` form
+the engine extracts from spec and checkpoint bodies. It is NOT for YAML
+frontmatter keys (e.g. `coverage_percent: 85` inside
+`verification-report.md`'s `---`-fenced header), which are parsed by the
+file-shape grammar and are excluded by the Scope section below.
 
 ### Recurrence history
 

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -870,3 +870,77 @@ Sections: Error Pattern Frequency (table: Category/Total/Last 10/Trend/Status), 
 
 Filed Issues rows may contain one URL or, for `target_repo: both`, both URLs
 on one line in the format defined by §issue-routing.
+
+---
+
+## Engine parser patterns
+
+The harness engine and downstream tooling parse metadata fields from
+`spec.md`, `output-summary.md`, `evaluation.md`, and other harness
+artifacts. Generator agents implementing new metadata fields, and
+checkpoint code introducing new metadata-field regexes, MUST adopt the
+defensive defaults below so the engine stays resilient to bold-decoration
+and other compatibility-only shape drift.
+
+### Compatibility envelope for metadata-field regexes
+
+Every metadata regex SHOULD tolerate `(\*\*)?` (or its PCRE-style
+non-capturing equivalent `(?:\*\*)?`) around the field name. Reference
+pattern, in portable ERE form (compatible with `grep -E` and `sed -E`):
+
+```
+^[[:space:]]*-[[:space:]]+(\*\*)?<field>(\*\*)?:[[:space:]]+(.+)$
+```
+
+PCRE-style equivalent (compatible with `grep -P` and Bash `[[ =~ ]]`):
+
+```
+^[[:space:]]*-[[:space:]]+(?:\*\*)?<field>(?:\*\*)?:[[:space:]]+(.+)$
+```
+
+Concretely, a metadata field named `Type` accepts both shapes on the same
+input line:
+
+| Shape                  | Canonical? | Engine reads it? | Spec Evaluator behavior         |
+|------------------------|------------|------------------|---------------------------------|
+| `- Type: backend`      | yes        | yes              | passes                          |
+| `- **Type**: backend`  | no (compat)| yes              | warns: normalize to canonical   |
+| `- *Type*: backend`    | no         | no               | error: invalid metadata         |
+
+This is the parser-side default for **all** metadata fields, not just
+`Type`. New fields introduced by checkpoints (for example
+`parallel_group`, `coverage_percent`, future cohort facets) MUST adopt
+the same envelope so a legacy or AI-emitted bold-decorated spec does not
+silently degrade to a parse miss. The Spec Evaluator continues to warn on
+the decorated form so the human author still gets a normalization hint;
+the parser-side envelope is purely a defensive default, not a license to
+emit the decorated shape.
+
+### Recurrence history
+
+This is a documented harness regression class. Recurrences in the retro
+log so far:
+
+- 2026-04-24 — `ENGINE-PARSER-FORMAT-DRIFT` (Type field).
+- 2026-04-26 — `PARSER-DECORATION-FRAGILITY` (legacy spec compatibility).
+- 2026-05-09 — `parallel-cohort-execution-v1` review-loop findings f6, f7
+  (`group_match`, `metadata_match`).
+
+Each instance had the same root cause: a hand-rolled metadata regex that
+only accepted the canonical un-bolded shape, paired with a Generator
+emitting the bold-decorated variant. Codifying the compatibility envelope
+as the parser-side default closes the class. See harness issue #40.
+
+### Scope
+
+This envelope is for metadata-field regexes — key/value lines the engine
+extracts from artifacts. It does NOT apply to:
+
+- Free-form prose (markdown body content, narrative sections).
+- Content where bold decoration is semantically meaningful (for example, a
+  checklist item where `**done**` is a status marker).
+- File-shape parsers (YAML frontmatter, JSON blobs) that have their own
+  language-level grammar.
+
+When in doubt: any line that becomes a structured field in a parsed
+artifact takes the envelope; markdown body content does not.

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -888,25 +888,41 @@ Every metadata regex SHOULD tolerate `(\*\*)?` (or its PCRE-style
 non-capturing equivalent `(?:\*\*)?`) around the field name. Reference
 pattern, in portable ERE form (compatible with `grep -E` and `sed -E`):
 
-```
+```regex
 ^[[:space:]]*-[[:space:]]+(\*\*)?<field>(\*\*)?:[[:space:]]+(.+)$
 ```
 
 PCRE-style equivalent (compatible with GNU `grep -P`; Bash `[[ =~ ]]`
 uses POSIX ERE, so use the ERE form above in shell scripts):
 
-```
+```regex
 ^[[:space:]]*-[[:space:]]+(?:\*\*)?<field>(?:\*\*)?:[[:space:]]+(.+)$
 ```
 
-Concretely, a metadata field named `Type` accepts both shapes on the same
-input line:
+The two forms have **different capture-group indices** for the value:
+
+- ERE `(\*\*)?<field>(\*\*)?` — value is in capture group **3** (the
+  optional `**` groups consume groups 1 and 2).
+- PCRE `(?:\*\*)?<field>(?:\*\*)?` — value is in capture group **1**
+  (the non-capturing `(?:...)` groups don't consume an index).
+
+Copying the wrong form into a parser is a silent-failure source; cite the
+form you use.
+
+Concretely, a metadata field named `Type` exercises each shape:
 
 | Shape                  | Canonical? | Engine reads it? | Spec Evaluator behavior         |
 |------------------------|------------|------------------|---------------------------------|
 | `- Type: backend`      | yes        | yes              | passes                          |
 | `- **Type**: backend`  | no (compat)| yes              | warns: normalize to canonical   |
+| `- **Type: backend`    | no (malformed) | yes (envelope is loose) | warns: paired bold markers required |
+| `- Type**: backend`    | no (malformed) | yes (envelope is loose) | warns: paired bold markers required |
 | `- *Type*: backend`    | no         | no               | error: invalid metadata         |
+
+The envelope is intentionally loose at the parser layer (independent
+`(\*\*)?` groups) so a one-sided bold typo still reaches the Spec
+Evaluator instead of disappearing as a parse miss; the Spec Evaluator is
+the strict gate that requires paired markers and emits the warning.
 
 This is the parser-side default for **all** bullet-shaped metadata
 fields, not just `Type`. New bullet fields introduced by checkpoints


### PR DESCRIPTION
## Summary

- Adds a new `Engine parser patterns` section to `protocol-quick-ref.md` that codifies the `(\*\*)?` envelope around metadata field names as the parser-side default for **all** metadata regexes.
- Adds a new Principle 8 ("Defensive parser patterns") to `harness-generator.md` that cites the new section by anchor, so any future "parse a new metadata field" checkpoint inherits the defensive default rather than hand-rolling a literal-canonical regex.
- Closes #40.

## Why

This is a documented regression class — three independent recurrences in the retro log:

| Date       | Pattern                            | Trigger field(s)             |
|------------|------------------------------------|------------------------------|
| 2026-04-24 | `ENGINE-PARSER-FORMAT-DRIFT`       | `Type`                       |
| 2026-04-26 | `PARSER-DECORATION-FRAGILITY`      | legacy spec compatibility    |
| 2026-05-09 | `parallel-cohort-execution-v1` f6/f7 | `group_match`, `metadata_match` |

Root cause is the same each time: a hand-rolled metadata regex that only accepts the canonical un-bolded shape, paired with a Generator emitting the bold-decorated variant. The fix is structural — codify the compatibility envelope as a parser-side default so future checkpoints inherit it.

## Scope

Doc-only. Two files touched (`protocol-quick-ref.md`, `harness-generator.md`); no engine code, no script behavior changes.

## What this PR does NOT do

- It does **not** retrofit existing metadata regexes in `harness-engine.sh` to use the envelope. That is a behavior change and belongs in a follow-up checkpoint with the canonical regex update tested against bold-decorated fixture specs.
- It does **not** add the proposed bold-decorated fixture to `scripts/test-spec-format-parallel-group.sh`. Per the issue body that fixture is already partially present post-fix; verifying and extending it should land alongside the engine retrofit.

## Test plan

- [x] Diff review: both edits land in their stated sections with consistent prose style.
- [x] No code changes — verified with `git diff --stat`: only `.md` files touched.
- [ ] Doc render review: confirm the new section renders cleanly in the protocol reference toolchain (mkdocs / GitHub markdown).
- [ ] Follow-up: open a separate issue for the engine-side retrofit + fixture spec referenced above.

## Follow-ups (not in this PR)

- Engine retrofit: update existing metadata regexes in `harness-engine.sh` (e.g., the `coverage_percent` grep at L1778) to consume the codified pattern, with a fixture covering bold-decorated forms.
- Lint script (`scripts/check-metadata-regex-envelope.sh`?) that asserts any new metadata regex in `harness-engine.sh` matches the `(\*\*)?` envelope, so the class stops recurring at PR time.

Cc: triage of the rest of the open issue backlog landed earlier today (issues #27, #29, #34–#44) with priority labels and per-issue assessments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an engine parser patterns reference describing defensive parsing rules for metadata fields, including handling optional bold decoration and portable regex forms with examples.
  * Updated harness generator guidance to require defensive parser patterns when checkpoint code introduces or modifies metadata-field regexes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/harness-engineering-skills/pull/45)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->