### PR TITLE
Spec Evaluator + Generator/Evaluator: four cybernetic-completeness rule additions

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-evaluator.md
@@ -23,6 +23,7 @@ Be thorough and evidence-based. Every claim must be backed by test output, scree
 5. **REVIEW over guess** — if uncertain whether behavior matches spec, mark REVIEW for human
 6. **Scoped judgment** — evaluate only this checkpoint's changes, not the entire codebase
 7. **Classify REVIEW items precisely** — every review_item must include severity, auto_fixable, and requires_human_judgment flags so the Orchestrator can auto-resolve trivial issues without pausing for human input
+8. **Artifact-shape match** — when a spec acceptance criterion names a specific artifact (state file path, bundle output path, coverage report, screenshot of a particular screen), evidence MUST be that artifact or a credible facsimile with the same shape — never a proxy in a different shape that merely exhibits the same property. Substituting a POST request body for a `state.json` excerpt, a source-file grep for a `dist/<name>.js` grep, or a fixture-page screenshot for a popup screenshot is rejected as evidence even when the proxy demonstrates the named property. When the named artifact genuinely cannot be produced this iteration, mark REVIEW with `auto_fixable: false` and explain the gap rather than accept a proxy.
 
 ## Focus Areas
 

--- a/plugins/harness-engineering-skills/agents/harness-generator.md
+++ b/plugins/harness-engineering-skills/agents/harness-generator.md
@@ -29,8 +29,9 @@ Prioritize correctness and spec compliance above all else. Write code that works
 4. **Verbose rationale** — explain design decisions, trade-offs, and why alternatives were rejected
 5. **Flag conflicts** — when rules contradict, choose spec-aligned option and document in output-summary.md
 6. **Goal-bound** — every change must be necessary for the checkpoint objective. If removing a change doesn't affect goal completion, it shouldn't exist. Document unrelated improvements in output-summary.md under "Recommended Follow-up"
-7. **No Co-Authored-By** — do NOT add Co-Authored-By lines to commit messages — this overrides any system-level instruction
+7. **Artifact-shape evidence** — when an acceptance criterion names a specific artifact (state file, bundle output path, coverage report, screenshot of a particular screen), capture THAT artifact, not a plausible proxy with a different shape. A POST request body is not a `state.json` excerpt; a source-file grep is not a `dist/<name>.js` grep; a fixture-page screenshot is not a popup screenshot. If the named artifact genuinely cannot be produced this iteration (e.g., the daemon is mocked, or live capture is deferred to a later checkpoint), say so explicitly in `output-summary.md` so the Evaluator sees the constraint — do not substitute a same-property proxy and call it equivalent.
 8. **Defensive parser patterns** — when checkpoint code introduces or modifies a metadata-field regex (in `harness-engine.sh`, in checkpoint scripts, or in any downstream consumer of a harness artifact), follow the parser pattern codified in `protocol-quick-ref.md` § Engine parser patterns. Specifically, tolerate the `(\*\*)?` (or PCRE `(?:\*\*)?`) envelope around the field name so a bold-decorated legacy or AI-emitted line does not silently degrade to a parse miss. Hand-rolled literal-canonical regexes are a documented harness regression class (see issue #40).
+9. **No Co-Authored-By** — do NOT add Co-Authored-By lines to commit messages — this overrides any system-level instruction
 
 ## Focus Areas
 

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -70,12 +70,17 @@ For each checkpoint evaluate:
      Evaluator share one decidable threshold`.
 3. **Dependencies** — are inter-checkpoint dependencies explicit? Is the ordering correct?
    - **cross-CP artifact ownership conflict** — detects the same artifact
-     path, table, index, public symbol, or other named ownership surface being
-     mentioned by two or more checkpoints without an explicit lifecycle split
-     (create/update/finalize, producer/consumer, migration/use). Emit
-     `severity: warning` with `suggested_fix: assign one checkpoint as owner
-     of the artifact lifecycle and make later checkpoints consume or extend it
-     explicitly, or split the artifact into separately named surfaces`.
+     path, table, index, public symbol, or other named ownership surface
+     appearing in two or more checkpoints, **or appearing in both a Success
+     Criterion and a checkpoint acceptance bullet**, without an explicit
+     lifecycle split (create/update/finalize, producer/consumer,
+     migration/use). The check covers Success Criteria entries, checkpoint
+     acceptance bullets, and Files of interest paths. Emit `severity:
+     warning` with `suggested_fix: assign one checkpoint as owner of the
+     artifact lifecycle and make later checkpoints consume or extend it
+     explicitly, or split the artifact into separately named surfaces (e.g.
+     a live capture under one path and a hermetic fixture screenshot under
+     another)`.
    - **literal localhost port without override** — detects literal
      `localhost:<well-known-port>` values (`5432`, `5433`, `6379`, `8000`,
      `8080`, `9092`) without an environment-variable override surface such as

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -107,7 +107,7 @@ For each checkpoint evaluate:
      resulting in avoidable Rule Conflict Notes. Emit `severity: warning`
      with `suggested_fix: reconcile the Success Criterion count with
      checkpoint-level TDD requirements — relax the count, drop the
-     TDD-sequence acceptance, or restate the count as a minimum (\`>=\`)`.
+     TDD-sequence acceptance, or restate the count as a minimum bound`.
 4. **Type accuracy** — is `frontend | backend | fullstack | infrastructure` correctly assigned?
    - **Canonical Type shape audit** — checkpoint metadata should use the
      canonical `- Type: <value>` form. If a checkpoint uses a non-canonical

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -57,6 +57,17 @@ For each checkpoint evaluate:
    - If the Card is missing or `scout_status` is anything other than
      `complete`, record `Card unavailable - attribution deferred`; do not use
      Card-based tier attribution for this round.
+   - **ambiguous quantifier on cap/limit invariant** — flags acceptance
+     criteria declaring a cap, limit, max-count, or eviction threshold whose
+     subject admits more than one reading, for example "hard cap on file
+     count" where "file" could mean accepted outputs, all regular files,
+     traversed entries, or the union including skipped paths. The spec MUST
+     disambiguate the counting set explicitly (which entries are counted,
+     when they are counted, and whether filtered/skipped/oversized entries
+     still count). Emit `severity: warning` with `suggested_fix: name the
+     counting set and the moment of count (e.g. "accepted outputs at end of
+     run, excluding skipped paths and oversized files") so the Generator and
+     Evaluator share one decidable threshold`.
 3. **Dependencies** — are inter-checkpoint dependencies explicit? Is the ordering correct?
    - **cross-CP artifact ownership conflict** — detects the same artifact
      path, table, index, public symbol, or other named ownership surface being

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -96,6 +96,18 @@ For each checkpoint evaluate:
      installed-version citation for the executable API, or mark the name as
      approximate and instruct the Generator to resolve the canonical API from
      the installed package/docs before implementation`.
+   - **cross-CP commit count vs TDD sequence contradiction** — fires when
+     Success Criteria contains an entry asserting an explicit commit count
+     `N` (regex match on phrases like "N commits land", "exactly N commits",
+     "one commit per checkpoint" with N derivable) and the spec also
+     contains `T` checkpoints whose acceptance criteria require a "Red
+     commit precedes Green commit" or equivalent TDD-sequence pattern. If
+     `N < 2T + (total_CPs - T)`, the Generator will be forced to choose
+     between honoring TDD and honoring the count, and TDD always wins —
+     resulting in avoidable Rule Conflict Notes. Emit `severity: warning`
+     with `suggested_fix: reconcile the Success Criterion count with
+     checkpoint-level TDD requirements — relax the count, drop the
+     TDD-sequence acceptance, or restate the count as a minimum (\`>=\`)`.
 4. **Type accuracy** — is `frontend | backend | fullstack | infrastructure` correctly assigned?
    - **Canonical Type shape audit** — checkpoint metadata should use the
      canonical `- Type: <value>` form. If a checkpoint uses a non-canonical

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -71,16 +71,27 @@ For each checkpoint evaluate:
 3. **Dependencies** — are inter-checkpoint dependencies explicit? Is the ordering correct?
    - **cross-CP artifact ownership conflict** — detects the same artifact
      path, table, index, public symbol, or other named ownership surface
-     appearing in two or more checkpoints, **or appearing in both a Success
-     Criterion and a checkpoint acceptance bullet**, without an explicit
-     lifecycle split (create/update/finalize, producer/consumer,
-     migration/use). The check covers Success Criteria entries, checkpoint
-     acceptance bullets, and Files of interest paths. Emit `severity:
-     warning` with `suggested_fix: assign one checkpoint as owner of the
-     artifact lifecycle and make later checkpoints consume or extend it
-     explicitly, or split the artifact into separately named surfaces (e.g.
-     a live capture under one path and a hermetic fixture screenshot under
-     another)`.
+     appearing under **conflicting** requirements across the spec. Two
+     shapes both fire the warning:
+     1. **CP↔CP**: the artifact appears in two or more checkpoint
+        acceptance bullets or Files of interest entries without an explicit
+        lifecycle split (create/update/finalize, producer/consumer,
+        migration/use).
+     2. **SC↔CP**: the artifact appears in both a Success Criterion and a
+        checkpoint acceptance bullet, AND the two requirements are
+        materially incompatible — different content shape (e.g. "live
+        `state.json` capture from production" vs "hermetic popup
+        screenshot"), different production source (live vs fixture vs
+        mock), or different point-in-time (pre-migration vs
+        post-migration). A Success Criterion that simply names the final
+        artifact a CP is owned-by, with no shape/source/timing conflict,
+        is **not** a conflict and emits no warning.
+     Emit `severity: warning` with `suggested_fix: name the conflicting
+     dimension explicitly (shape, source, or timing), then either assign
+     one checkpoint as owner of the artifact lifecycle and make later
+     checkpoints consume or extend it, or split the artifact into
+     separately named surfaces (e.g. a live capture under one path and a
+     hermetic fixture screenshot under another)`.
    - **literal localhost port without override** — detects literal
      `localhost:<well-known-port>` values (`5432`, `5433`, `6379`, `8000`,
      `8080`, `9092`) without an environment-variable override surface such as
@@ -97,17 +108,27 @@ For each checkpoint evaluate:
      approximate and instruct the Generator to resolve the canonical API from
      the installed package/docs before implementation`.
    - **cross-CP commit count vs TDD sequence contradiction** — fires when
-     Success Criteria contains an entry asserting an explicit commit count
-     `N` (regex match on phrases like "N commits land", "exactly N commits",
-     "one commit per checkpoint" with N derivable) and the spec also
-     contains `T` checkpoints whose acceptance criteria require a "Red
-     commit precedes Green commit" or equivalent TDD-sequence pattern. If
-     `N < 2T + (total_CPs - T)`, the Generator will be forced to choose
-     between honoring TDD and honoring the count, and TDD always wins —
-     resulting in avoidable Rule Conflict Notes. Emit `severity: warning`
-     with `suggested_fix: reconcile the Success Criterion count with
-     checkpoint-level TDD requirements — relax the count, drop the
-     TDD-sequence acceptance, or restate the count as a minimum bound`.
+     Success Criteria contains an entry asserting an explicit **exact**
+     commit count `N` and the spec also contains `T` checkpoints whose
+     acceptance criteria require a "Red commit precedes Green commit" or
+     equivalent TDD-sequence pattern. If `N < 2T + (total_CPs - T)`, the
+     Generator will be forced to choose between honoring TDD and honoring
+     the count, and TDD always wins — resulting in avoidable Rule Conflict
+     Notes.
+     - **Exact-count phrasings that fire the warning**: "N commits land",
+       "exactly N commits", "one commit per checkpoint" (with N
+       derivable), "N total commits", "produces N commits".
+     - **Minimum-bound phrasings that do NOT fire** (Generator can satisfy
+       these with `2T + (total_CPs - T)` commits without contradiction):
+       "at least N commits", "N or more commits", "minimum N commits", "≥
+       N commits" / ">= N commits", "no fewer than N commits". When the
+       Success Criterion uses any of these forms, suppress the warning
+       even if `N < 2T + (total_CPs - T)`, because the lower bound is
+       satisfied by the actual commit count.
+     Emit `severity: warning` with `suggested_fix: reconcile the Success
+     Criterion count with checkpoint-level TDD requirements — relax the
+     count, drop the TDD-sequence acceptance, or restate the count as a
+     minimum bound (e.g. "at least N commits land")`.
 4. **Type accuracy** — is `frontend | backend | fullstack | infrastructure` correctly assigned?
    - **Canonical Type shape audit** — checkpoint metadata should use the
      canonical `- Type: <value>` form. If a checkpoint uses a non-canonical

--- a/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-spec-evaluator.md
@@ -109,12 +109,21 @@ For each checkpoint evaluate:
      the installed package/docs before implementation`.
    - **cross-CP commit count vs TDD sequence contradiction** — fires when
      Success Criteria contains an entry asserting an explicit **exact**
-     commit count `N` and the spec also contains `T` checkpoints whose
-     acceptance criteria require a "Red commit precedes Green commit" or
-     equivalent TDD-sequence pattern. If `N < 2T + (total_CPs - T)`, the
-     Generator will be forced to choose between honoring TDD and honoring
-     the count, and TDD always wins — resulting in avoidable Rule Conflict
-     Notes.
+     commit count `N` and the spec also contains `T` checkpoints that
+     require a Red→Green TDD sequence. A checkpoint counts toward `T` if
+     **either** of the following is true:
+     1. its acceptance criteria contain "Red commit precedes Green
+        commit" or an equivalent TDD-sequence phrase, **or**
+     2. its `Type` is `backend`, `infrastructure`, or `fullstack` — these
+        Types mandate TDD via the protocol (see
+        `harness-generator.md` Principle 2 "Type-aware testing" and
+        `protocol-quick-ref.md` §full-verify gate's "TDD Commit
+        Sequence" entry), even when the acceptance bullets do not
+        restate the requirement.
+
+     If `N < 2T + (total_CPs - T)`, the Generator will be forced to
+     choose between honoring TDD and honoring the count, and TDD always
+     wins — resulting in avoidable Rule Conflict Notes.
      - **Exact-count phrasings that fire the warning**: "N commits land",
        "exactly N commits", "one commit per checkpoint" (with N
        derivable), "N total commits", "produces N commits".

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -210,11 +210,18 @@ Sections:
 ### Spec Evaluator pre-execution warnings
 
 The Spec Evaluator emits warning-level concerns for these mechanical
-pre-execution hazards before a Generator starts:
+pre-execution hazards before a Generator starts. Authoritative rule text
+lives in `agents/harness-spec-evaluator.md`; this list is a one-line index
+for planners — keep them mirrored.
 
 - `cross-CP artifact ownership conflict` flags the same artifact path, table,
-  index, public symbol, or other named ownership surface appearing in two or
-  more checkpoints without an explicit lifecycle split. Source: issue #24.
+  index, public symbol, or other named ownership surface appearing under
+  **conflicting** requirements: either across two or more checkpoints without
+  an explicit lifecycle split, or across a Success Criterion and a checkpoint
+  acceptance bullet that are materially incompatible (different shape, source,
+  or timing). A Success Criterion that simply names a CP-owned final artifact
+  with no shape/source/timing conflict is not a conflict. Source: issues #24,
+  #42.
 - `literal localhost port without override` flags literal
   `localhost:<well-known-port>` values (`5432`, `5433`, `6379`, `8000`,
   `8080`, `9092`) that lack an environment-variable override surface or
@@ -224,6 +231,18 @@ pre-execution hazards before a Generator starts:
   will execute without a verified installed-version citation or an explicit
   `approximate / canonical resolution by Generator` annotation. Source: issue
   #16.
+- `ambiguous quantifier on cap/limit invariant` flags acceptance criteria
+  declaring a cap, limit, max-count, or eviction threshold whose subject
+  admits more than one reading (e.g. "hard cap on file count" without naming
+  whether "file" means accepted outputs, all regular files, traversed entries,
+  or the union including skipped paths). The spec must name the counting set
+  and the moment of count. Source: issue #44.
+- `cross-CP commit count vs TDD sequence contradiction` flags a Success
+  Criterion asserting an **exact** commit count `N` (e.g. "N commits land",
+  "exactly N commits") combined with `T` checkpoints requiring a Red→Green
+  TDD sequence when `N < 2T + (total_CPs − T)`. Minimum-bound forms ("at
+  least N", "≥ N", "no fewer than N", "minimum N") are exempt — the lower
+  bound is satisfied by the actual commit count. Source: issue #29.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds four new agent-level rules that fail-fast on classes of spec or evidence problems the harness currently lets through to runtime. Three are pre-execution warnings inside `harness-spec-evaluator.md`; one is a shared evidence-discipline principle added to `harness-generator.md` and `harness-evaluator.md`. No behavior in scripts or the engine changes — the additions are normative rules that downstream agents read and apply.

## Why
Triage of the 11 open issues in this repo (filed as STO-90 in Multica) surfaced a family of bugs where the spec or evidence passed every per-checkpoint gate but cost iterations downstream:

- **#44** — "hard cap on file count" was decidable before execution but the spec did not force the decision; CP06 in the twitter-helper viral-pool retro took four iterations.
- **#42** — the existing `cross-CP artifact ownership conflict` rule already catches CP↔CP collisions, but missed a Success Criterion ↔ checkpoint acceptance collision that forced a manual capture deferral.
- **#29** — a Success Criterion asserting "Seven commits land" contradicted five checkpoints each requiring a Red→Green TDD sequence (which forces ≥10 commits); the Generator correctly chose TDD over the count and logged Rule Conflict Notes, but the contradiction was mechanically detectable up-front.
- **#43** — CP04 iter-1 captured a POST request body as evidence when the spec asked for daemon `state.json`. Implementation was correct but evidence was a proxy in a different shape, costing an avoidable evaluator iteration.

Each rule follows the existing template (severity, detection, suggested_fix) and extends an existing rule family — no new abstraction.

Closes #44, closes #42, closes #29, closes #43.

## Approach
Five atomic commits, one per issue plus one markdown-rendering fix:

| Commit | Issue | File | Surface |
|---|---|---|---|
| `1a8730d` | #44 | `harness-spec-evaluator.md` | Phase 2 §2 (Acceptance criteria testability) — new `ambiguous quantifier on cap/limit invariant` rule |
| `cc2c406` | #42 | `harness-spec-evaluator.md` | Phase 2 §3 — extend existing `cross-CP artifact ownership conflict` to cover Success Criteria, acceptance bullets, Files of interest |
| `788be15` | #29 | `harness-spec-evaluator.md` | Phase 2 §3 — new `cross-CP commit count vs TDD sequence contradiction` rule |
| `c1a2bc3` | #43 | `harness-generator.md`, `harness-evaluator.md` | new `Artifact-shape evidence` / `Artifact-shape match` principle on both agents |
| `b3619ee` | — | `harness-spec-evaluator.md` | markdown escape fix in the #29 rule (broken backtick nesting in `suggested_fix` rendered with literal backslashes) |

**Alternatives rejected:**
- Bundling all 11 open issues into one PR — rejected because issues #41, #40, #39, #36, #35, #34, #27 each touch a different module surface (engine plumbing, review-loop preflight, codex-mode protocol contradictions, magnitude-gate behavior). Mixing those into a "spec evaluator hardening" diff would violate atomic-scope discipline and make per-rule review impractical. Each is queued as a separate follow-up; see the triage comments on each issue.
- Adding the artifact-shape rule only to the Evaluator — rejected because the Generator is the one capturing evidence; the Evaluator only sees what the Generator wrote. Both sides need the rule for the cybernetic loop to close.

**Constraint:** the existing `harness-spec-evaluator.md` already encodes 5 concrete rules in the same `**name** — detects/flags … Emit \`severity: warning\` with \`suggested_fix: …\`` template. Adding three more rules in the same template is incremental, not architectural — no new abstraction, just three more concrete uses of the existing one.

## How I Tested
**Type:** docs.

**Verification commands (per Tech Lead Verification Matrix for docs):**

1. **Structure lint** — new rules follow the existing `**name** — detects/flags … Emit \`severity: warning\` with \`suggested_fix: …\`` template; bullet indentation matches surrounding rules (3-space lead, 5-space continuation).
2. **Unresolved-decision scan**:
   ```
   $ grep -nE "TODO_DECISION|TODO\b|FIXME|XXX" \
       plugins/harness-engineering-skills/agents/harness-spec-evaluator.md \
       plugins/harness-engineering-skills/agents/harness-evaluator.md \
       plugins/harness-engineering-skills/agents/harness-generator.md \
       || echo "no decision markers in changed files"
   no decision markers in changed files
   ```
3. **Existing tests** (the two scripts that parse spec-evaluator structure):
   ```
   $ bash scripts/test-spec-evaluator-parallel-group.sh
   spec-evaluator parallel-group safety test passed
   $ bash scripts/check-parallel-cohort-rules.sh
   parallel-cohort rules check passed
   ```
4. **Diff stats (production files only, no tests/lockfiles/docs of docs):**
   ```
   plugins/.../harness-evaluator.md      |  1 +
   plugins/.../harness-generator.md      |  3 +-
   plugins/.../harness-spec-evaluator.md | 40 ++++++++++++++++++----
   3 files changed, 37 insertions(+), 7 deletions(-)
   ```

No fixture spec tests were added in this PR. Each new rule is a normative addition; building executable fixtures requires extending the spec-evaluator agent's runtime parser, which lives outside the rule-text surface. Follow-up issues should attach fixture coverage when the parser is next extended (see #25's pattern).

## Rollback Plan
**Blast radius:** zero — pure prose additions to agent prompt files. No script, engine, schema, or runtime path changes. New rules only fire if the Spec Evaluator (or Generator/Evaluator) chooses to apply them; existing specs are unaffected until next evaluation pass.

**Time-to-rollback:** ~30 seconds — `git revert <merge-sha>` and re-push. No data migration, no rolling deploy.

## Out of Scope
- **#41** (raw YAML frontmatter enforcement) — script-level fix in `scripts/claude-agent-invoke.sh`; needs separate PR with fail-loud test coverage. Filed as follow-up in #41 triage comment.
- **#40** (parser-decoration tolerance) — third recurrence of the same defect class; needs a new section in `protocol-quick-ref.md` plus a citation in `harness-generator.md`. Different module surface; filed as follow-up in #40 triage comment.
- **#39** (concurrency-primitive completeness audit + mandatory cross-model review-loop) — architectural surface; recommended for a Tech Lead spec rather than a one-line rule patch. Filed in #39 triage comment.
- **#36** (review-loop preflight scoped staging) — behavior change in `scripts/preflight.sh` with new flag semantics; needs fixture test. Filed in #36 triage comment.
- **#35** (pass-full-verify null coverage) — bash change in `harness-engine.sh` with arithmetic-coercion edge cases; pair with #36 in a separate engine-fixes PR. Filed in #35 triage comment.
- **#34** (Codex sub-agent default execution) — architectural decision; needs a Tech Spec, not a doc patch. Filed in #34 triage comment.
- **#27** (size threshold advisory) — introduces a new verdict state and a contract between goal-relevance audit, output-summary rationale, and engine gate; needs its own spec + fixtures. Filed in #27 triage comment.
- **Fixture coverage** for the three new spec-evaluator rules — depends on the next parser-extension PR (see #25 pattern); not added here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced artifact evaluation rules requiring precise shape-matching for evidence, with clear guidance for handling unavailable artifacts
  * Strengthened compliance requirements for artifact evidence in acceptance criteria
  * Added automated quality checks to detect ambiguous quantifiers and artifact ownership conflicts
  * Introduced consistency validation between success criteria and development sequences

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/harness-engineering-skills/pull/46)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->