### PR TITLE
fix(harness): enforce raw YAML frontmatter in evaluator artifacts (#41)

### DIFF
--- a/plugins/harness-engineering-skills/skills/harness/scripts/claude-agent-invoke.sh
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/claude-agent-invoke.sh
@@ -141,15 +141,26 @@ parse_claude_json() {
   local log_file="$1"
   local output_file="$2"
   local session_id_file="${3:-}"
+  local agent_name="${4:-claude}"
 
-  python3 - "$log_file" "$output_file" "$session_id_file" <<'PY'
+  local raw_result_file is_error_file existing_artifact_file
+  raw_result_file="$(mktemp "${TMPDIR:-/tmp}/harness-claude-result.XXXXXX")"
+  is_error_file="$(mktemp "${TMPDIR:-/tmp}/harness-claude-is-error.XXXXXX")"
+  existing_artifact_file=""
+  if [[ -f "$output_file" ]]; then
+    existing_artifact_file="$(mktemp "${TMPDIR:-/tmp}/harness-claude-existing.XXXXXX")"
+    cp "$output_file" "$existing_artifact_file"
+  fi
+
+  python3 - "$log_file" "$raw_result_file" "${session_id_file:-}" "$is_error_file" <<'PY'
 import json
 import pathlib
 import sys
 
 log_path = pathlib.Path(sys.argv[1])
-output_path = pathlib.Path(sys.argv[2])
+raw_result_path = pathlib.Path(sys.argv[2])
 session_id_path = pathlib.Path(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else None
+is_error_path = pathlib.Path(sys.argv[4])
 
 text = log_path.read_text()
 try:
@@ -182,26 +193,53 @@ for event in events:
 if result_text is None:
     raise SystemExit("Error: Claude agent output did not include a result payload")
 
-if output_path.exists():
-    existing_text = output_path.read_text()
-else:
-    existing_text = ""
-
-if existing_text.strip() and not result_text.lstrip().startswith("---"):
-    # Some Claude agents write the requested artifact directly and return a
-    # prose summary as their final result. Preserve the structured artifact in
-    # that case; otherwise the harness gate loses its frontmatter.
-    pass
-else:
-    output_path.write_text(result_text)
+raw_result_path.write_text(result_text)
+is_error_path.write_text("1" if is_error else "0")
 
 if session_id_path:
     session_id_path.write_text(f"{session_id}\n")
-
-if is_error:
-    print(f"Error: Claude agent returned an error: {result_text}", file=sys.stderr)
-    sys.exit(1)
 PY
+  local extract_rc=$?
+
+  if [[ "$extract_rc" -ne 0 ]]; then
+    rm -f "$raw_result_file" "$is_error_file"
+    [[ -n "$existing_artifact_file" ]] && rm -f "$existing_artifact_file"
+    return "$extract_rc"
+  fi
+
+  # Normalize and validate the raw result text. The normalizer either writes a
+  # frontmatter-compliant artifact to "$output_file", preserves an existing
+  # valid on-disk artifact, or writes a structured parse-error YAML and exits
+  # non-zero. Behavior is identical for Claude review-role artifacts emitted
+  # via stream-json — the helper centralizes the contract so future host
+  # adapters (Codex, Gemini) share one implementation.
+  local normalizer="$SCRIPT_DIR/normalize_claude_artifact.py"
+  local normalize_args=(
+    --agent "$agent_name"
+    --result-file "$raw_result_file"
+    --output-file "$output_file"
+  )
+  if [[ -n "$existing_artifact_file" ]]; then
+    normalize_args+=(--existing-file "$existing_artifact_file")
+  fi
+
+  python3 "$normalizer" "${normalize_args[@]}"
+  local normalize_rc=$?
+
+  local is_error="0"
+  if [[ -f "$is_error_file" ]]; then
+    is_error="$(<"$is_error_file")"
+  fi
+
+  rm -f "$raw_result_file" "$is_error_file"
+  [[ -n "$existing_artifact_file" ]] && rm -f "$existing_artifact_file"
+
+  if [[ "$is_error" == "1" ]]; then
+    echo "Error: Claude agent returned an error (is_error=true in result event)" >&2
+    return 1
+  fi
+
+  return "$normalize_rc"
 }
 
 # Stay in the caller's working directory (the user's project).
@@ -264,4 +302,4 @@ if [[ $exit_code -ne 0 ]]; then
   exit "$exit_code"
 fi
 
-parse_claude_json "$RUN_LOG" "$OUTPUT_FILE" "$SESSION_ID_FILE"
+parse_claude_json "$RUN_LOG" "$OUTPUT_FILE" "$SESSION_ID_FILE" "$AGENT_NAME"

--- a/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
@@ -530,6 +530,21 @@ import sys
 path = pathlib.Path(sys.argv[1])
 text = path.read_text() if path.exists() else ""
 
+# Refuse to read a verdict from a parse-error artifact. The normalizer
+# (plugins/.../normalize_claude_artifact.py) writes
+# `result: parse-error` in the frontmatter and preserves the agent's raw
+# bytes verbatim in an indented body for retro evidence. Without this
+# short-circuit the patterns below would happily match an indented
+# `  verdict: PASS` line inside that body and let a malformed agent
+# output silently pass the gate.
+frontmatter_match = re.match(r"\A---\r?\n(.*?)\r?\n---\r?\n", text, re.DOTALL)
+if frontmatter_match and re.search(
+    r"^result\s*:\s*parse-error\s*$",
+    frontmatter_match.group(1),
+    re.MULTILINE,
+):
+    sys.exit(0)
+
 patterns = [
     r"(?im)^\s*verdict\s*:\s*(PASS_WITH_WARNINGS|PASS|FAIL|REVIEW)\s*$",
     r"(?im)^\s*[-*]?\s*\*\*result\*\*\s*:\s*(PASS_WITH_WARNINGS|PASS|FAIL|REVIEW)\b",

--- a/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Normalize and validate agent result artifacts to raw YAML frontmatter contract.
+
+Agent processes (Claude, Codex, Gemini) sometimes wrap their final-result text
+in markdown code fences, prefix the YAML frontmatter with a list-item marker
+(``- ---``), or emit leading blank lines. The harness engine's frontmatter
+parser requires the artifact's first three characters to be raw ``---`` and a
+matching closing ``---`` line; malformed shapes force the operator to normalize
+by hand before the verdict can be consumed.
+
+This helper centralizes the normalize-and-validate logic so every agent-invoke
+script (claude-agent-invoke.sh today, codex/gemini counterparts when #34
+lands) can call into one implementation rather than each open-coding its own.
+
+CLI usage::
+
+    normalize_claude_artifact.py \\
+        --agent <agent-name> \\
+        --result-file <path-to-raw-result> \\
+        --output-file <path-to-write> \\
+        [--existing-file <path-to-current-artifact>]
+
+Exit codes:
+
+* 0 — normalized artifact written, or existing artifact preserved
+* 2 — malformed input and no preservable existing artifact; parse-error YAML
+      written to output_file
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+_LEADING_FENCE_RE = re.compile(r"\A```[A-Za-z0-9_+-]*[ \t]*\r?\n")
+_TRAILING_FENCE_RE = re.compile(r"\r?\n```[ \t]*\r?\n?[ \t]*\Z")
+
+
+def normalize_and_validate(text: str) -> tuple[str, str | None]:
+    """Normalize agent result text and validate raw YAML frontmatter contract.
+
+    Returns ``(normalized_text, error)`` where ``error`` is ``None`` on success
+    and a human-readable diagnostic string when the contract is violated.
+
+    Normalization steps (applied in order):
+
+    1. Strip leading whitespace and blank lines.
+    2. Strip a leading markdown code fence (e.g. ``` ```yaml ```` ``` ``` ``)
+       and, if present, the matching trailing fence.
+    3. Strip a leading ``- `` list-item prefix from a ``- ---`` first line.
+    4. Re-trim leading blank lines after normalization.
+
+    Validation:
+
+    * First non-empty line MUST be exactly ``---``.
+    * A closing ``---`` line MUST appear somewhere after the opener.
+    """
+    work = text.lstrip()
+
+    fence_match = _LEADING_FENCE_RE.match(work)
+    if fence_match:
+        work = work[fence_match.end():]
+        trailing_match = _TRAILING_FENCE_RE.search(work)
+        if trailing_match:
+            work = work[: trailing_match.start()] + "\n"
+
+    if work.startswith("- ---"):
+        work = work[2:]
+
+    work = work.lstrip("\n")
+
+    lines = work.splitlines()
+    if not lines:
+        return work, "result is empty after normalization"
+
+    first_line = lines[0].rstrip()
+    if first_line != "---":
+        sample = first_line if len(first_line) <= 120 else first_line[:117] + "..."
+        return work, (
+            f"first non-empty line is not '---' "
+            f"(got {sample!r}; expected raw YAML frontmatter opener)"
+        )
+
+    has_closing = any(line.rstrip() == "---" for line in lines[1:])
+    if not has_closing:
+        return work, "no closing '---' line found after opening frontmatter"
+
+    return work, None
+
+
+def _has_valid_opening(text: str) -> bool:
+    stripped = text.lstrip()
+    if not stripped:
+        return False
+    first_line = stripped.splitlines()[0].rstrip()
+    return first_line == "---"
+
+
+def _build_parse_error_artifact(
+    agent: str, error: str, raw_text: str
+) -> str:
+    """Produce a YAML-framed parse-error artifact the engine can consume."""
+    first_nonempty = next(
+        (line for line in raw_text.splitlines() if line.strip()),
+        "",
+    )
+    sample = first_nonempty if len(first_nonempty) <= 200 else first_nonempty[:197] + "..."
+    indented_raw = "\n".join(f"  {line}" for line in raw_text.splitlines())
+    return (
+        "---\n"
+        "result: parse-error\n"
+        f"agent: {agent}\n"
+        "reason: malformed-artifact-shape\n"
+        f"detail: {_yaml_inline(error)}\n"
+        f"first_line: {_yaml_inline(sample)}\n"
+        "---\n"
+        "\n"
+        "The agent's final result did not conform to the raw YAML frontmatter\n"
+        "contract. The engine's frontmatter parser requires the artifact's first\n"
+        "non-empty line to be exactly `---` and a matching closing `---` line to\n"
+        "appear later. See `reason` and `detail` above for the specific\n"
+        "violation. Raw agent output is preserved verbatim below for retro:\n"
+        "\n"
+        "```\n"
+        f"{indented_raw}\n"
+        "```\n"
+    )
+
+
+def _yaml_inline(value: str) -> str:
+    """Quote a value safely for a single-line YAML scalar."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _process(
+    agent: str,
+    result_file: pathlib.Path,
+    output_file: pathlib.Path,
+    existing_file: pathlib.Path | None,
+) -> int:
+    if not result_file.exists():
+        sys.stderr.write(f"Error: result file not found: {result_file}\n")
+        return 2
+
+    raw_text = result_file.read_text()
+    normalized, error = normalize_and_validate(raw_text)
+
+    if error is None:
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(normalized)
+        return 0
+
+    existing_text = ""
+    if existing_file and existing_file.exists():
+        existing_text = existing_file.read_text()
+
+    if existing_text.strip() and _has_valid_opening(existing_text):
+        sys.stderr.write(
+            f"Warning: agent {agent!r} returned non-frontmatter result "
+            f"({error}); preserving existing on-disk artifact at {existing_file}\n"
+        )
+        return 0
+
+    parse_error_yaml = _build_parse_error_artifact(agent, error, raw_text)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(parse_error_yaml)
+    sys.stderr.write(
+        f"Error: agent {agent!r} emitted malformed artifact ({error}). "
+        f"Parse-error YAML written to {output_file}.\n"
+    )
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    summary = (__doc__ or "Normalize agent artifacts.").splitlines()[0]
+    parser = argparse.ArgumentParser(description=summary)
+    parser.add_argument("--agent", required=True, help="Agent name for diagnostics")
+    parser.add_argument(
+        "--result-file",
+        required=True,
+        type=pathlib.Path,
+        help="Path to raw result text from the agent",
+    )
+    parser.add_argument(
+        "--output-file",
+        required=True,
+        type=pathlib.Path,
+        help="Path to write the normalized (or parse-error) artifact",
+    )
+    parser.add_argument(
+        "--existing-file",
+        type=pathlib.Path,
+        default=None,
+        help="Optional path checked when result is malformed; if it contains a "
+        "valid frontmatter opener, preserve it instead of overwriting",
+    )
+    args = parser.parse_args(argv)
+    return _process(args.agent, args.result_file, args.output_file, args.existing_file)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py
@@ -36,6 +36,7 @@ import sys
 
 _LEADING_FENCE_RE = re.compile(r"\A```[A-Za-z0-9_+-]*[ \t]*\r?\n")
 _TRAILING_FENCE_RE = re.compile(r"\r?\n```[ \t]*\r?\n?[ \t]*\Z")
+_LEADING_BLANK_LINES_RE = re.compile(r"\A(?:[ \t]*\r?\n)+")
 
 
 def normalize_and_validate(text: str) -> tuple[str, str | None]:
@@ -69,7 +70,7 @@ def normalize_and_validate(text: str) -> tuple[str, str | None]:
     if work.startswith("- ---"):
         work = work[2:]
 
-    work = work.lstrip("\n")
+    work = _LEADING_BLANK_LINES_RE.sub("", work)
 
     lines = work.splitlines()
     if not lines:
@@ -90,12 +91,24 @@ def normalize_and_validate(text: str) -> tuple[str, str | None]:
     return work, None
 
 
-def _has_valid_opening(text: str) -> bool:
-    stripped = text.lstrip()
-    if not stripped:
+def _has_valid_frontmatter(text: str) -> bool:
+    """Check that ``text`` is a valid raw YAML frontmatter artifact.
+
+    Mirrors the contract enforced on newly-emitted results: the first line
+    must be exactly ``---`` (no leading whitespace, no fence, no list-item
+    prefix) and a closing ``---`` line must appear somewhere after the opener.
+
+    A file that only has an opener — for example a stale ``---\\nverdict:
+    PASS\\n`` left over from an interrupted write — is *not* preserved; the
+    fresh malformed result still triggers a parse-error so retro evidence can
+    surface the failure instead of letting an old PASS pass through.
+    """
+    if not text:
         return False
-    first_line = stripped.splitlines()[0].rstrip()
-    return first_line == "---"
+    lines = text.splitlines()
+    if not lines or lines[0].rstrip() != "---":
+        return False
+    return any(line.rstrip() == "---" for line in lines[1:])
 
 
 def _build_parse_error_artifact(
@@ -157,7 +170,7 @@ def _process(
     if existing_file and existing_file.exists():
         existing_text = existing_file.read_text()
 
-    if existing_text.strip() and _has_valid_opening(existing_text):
+    if _has_valid_frontmatter(existing_text):
         sys.stderr.write(
             f"Warning: agent {agent!r} returned non-frontmatter result "
             f"({error}); preserving existing on-disk artifact at {existing_file}\n"

--- a/scripts/test-claude-agent-invoke-e2e.sh
+++ b/scripts/test-claude-agent-invoke-e2e.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-claude-agent-invoke-e2e.sh — End-to-end check of the malformed-artifact
+# fail-loud path through claude-agent-invoke.sh. Uses a stubbed `claude` CLI on
+# PATH that emits a pre-recorded stream-json log, so the test does not require
+# a real Claude session.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$repo_root/plugins/harness-engineering-skills/skills/harness/scripts/claude-agent-invoke.sh"
+
+if [[ ! -f "$script" ]]; then
+  echo "Error: $script not found" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/test-helpers.sh
+source "$repo_root/scripts/lib/test-helpers.sh"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/harness-claude-e2e-XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+
+# Stub `claude` CLI: echo the contents of a fixture log file specified via
+# HARNESS_TEST_STUB_LOG. This bypasses the real Claude process while preserving
+# the script's input/output contract.
+mkdir -p "$workdir/bin"
+cat > "$workdir/bin/claude" <<'STUB'
+#!/usr/bin/env bash
+# Drain stdin so callers do not stall waiting on the prompt.
+cat > /dev/null
+if [[ -z "${HARNESS_TEST_STUB_LOG:-}" || ! -f "$HARNESS_TEST_STUB_LOG" ]]; then
+  echo "stub claude: HARNESS_TEST_STUB_LOG not set or not a file" >&2
+  exit 99
+fi
+cat "$HARNESS_TEST_STUB_LOG"
+STUB
+chmod +x "$workdir/bin/claude"
+
+prompt_file="$workdir/prompt.txt"
+echo "stub prompt" > "$prompt_file"
+
+invoke_with_stub_log() {
+  local stub_log="$1"
+  local output_file="$2"
+  HARNESS_TEST_STUB_LOG="$stub_log" \
+    PATH="$workdir/bin:$PATH" \
+    "$script" \
+      --agent harness-evaluator \
+      --prompt-file "$prompt_file" \
+      --output-file "$output_file"
+}
+
+scenario=1
+echo "[$scenario] valid frontmatter result_text passes through end-to-end"
+stub_log1="$workdir/stub1.jsonl"
+out1="$workdir/out1.md"
+python3 - "$stub_log1" <<'PY'
+import json, sys
+p = open(sys.argv[1], "w")
+p.write(json.dumps({"type": "system", "session_id": "s-abc"}) + "\n")
+p.write(json.dumps({
+    "type": "result",
+    "session_id": "s-abc",
+    "is_error": False,
+    "result": "---\nverdict: pass\nscore: 9\n---\n\nEvaluation body.\n",
+}) + "\n")
+p.close()
+PY
+invoke_with_stub_log "$stub_log1" "$out1" > /dev/null 2>&1
+assert_contains "$out1" "verdict: pass"
+assert_contains "$out1" "Evaluation body."
+((scenario++))
+
+echo "[$scenario] backtick-yaml-fenced result_text is normalized"
+stub_log2="$workdir/stub2.jsonl"
+out2="$workdir/out2.md"
+python3 - "$stub_log2" <<'PY'
+import json, sys
+fenced = "```yaml\n---\nverdict: review\n---\n\nNotes\n```\n"
+with open(sys.argv[1], "w") as p:
+    p.write(json.dumps({"type": "system", "session_id": "s-xyz"}) + "\n")
+    p.write(json.dumps({
+        "type": "result",
+        "session_id": "s-xyz",
+        "is_error": False,
+        "result": fenced,
+    }) + "\n")
+PY
+invoke_with_stub_log "$stub_log2" "$out2" > /dev/null 2>&1
+first_line=$(head -n 1 "$out2")
+if [[ "$first_line" != "---" ]]; then
+  echo "scenario $scenario: first line of $out2 is not '---' (got '$first_line')" >&2
+  cat "$out2" >&2
+  exit 1
+fi
+assert_contains "$out2" "verdict: review"
+((scenario++))
+
+echo "[$scenario] missing closing '---' triggers fail-loud + parse-error artifact"
+stub_log3="$workdir/stub3.jsonl"
+out3="$workdir/out3.md"
+python3 - "$stub_log3" <<'PY'
+import json, sys
+broken = "---\nverdict: pass\nnotes: no closing fence\n"
+with open(sys.argv[1], "w") as p:
+    p.write(json.dumps({"type": "system", "session_id": "s-bad"}) + "\n")
+    p.write(json.dumps({
+        "type": "result",
+        "session_id": "s-bad",
+        "is_error": False,
+        "result": broken,
+    }) + "\n")
+PY
+set +e
+invoke_with_stub_log "$stub_log3" "$out3" > "$workdir/out3.log" 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "scenario $scenario: expected non-zero exit, got 0" >&2
+  cat "$workdir/out3.log" >&2
+  exit 1
+fi
+assert_contains "$out3" "result: parse-error"
+assert_contains "$out3" "agent: harness-evaluator"
+((scenario++))
+
+echo "[$scenario] is_error=true propagates through normalize"
+stub_log4="$workdir/stub4.jsonl"
+out4="$workdir/out4.md"
+python3 - "$stub_log4" <<'PY'
+import json, sys
+result = "---\nverdict: error\ndetail: agent crashed\n---\n"
+with open(sys.argv[1], "w") as p:
+    p.write(json.dumps({"type": "system", "session_id": "s-err"}) + "\n")
+    p.write(json.dumps({
+        "type": "result",
+        "session_id": "s-err",
+        "is_error": True,
+        "result": result,
+    }) + "\n")
+PY
+set +e
+invoke_with_stub_log "$stub_log4" "$out4" > "$workdir/out4.log" 2>&1
+rc=$?
+set -e
+if [[ "$rc" -ne 1 ]]; then
+  echo "scenario $scenario: expected exit 1 (is_error), got $rc" >&2
+  cat "$workdir/out4.log" >&2
+  exit 1
+fi
+# File should still contain the (well-formed) error artifact for retro.
+assert_contains "$out4" "verdict: error"
+
+echo "claude-agent-invoke e2e fail-loud test passed (${scenario} scenarios)"

--- a/scripts/test-claude-artifact-frontmatter.sh
+++ b/scripts/test-claude-artifact-frontmatter.sh
@@ -12,8 +12,11 @@ set -euo pipefail
 #   5. Leading blank lines are stripped.
 #   6. Missing closing "---" fails loud (exit 2) AND writes parse-error YAML.
 #   7. Empty result fails loud.
-#   8. When result is malformed but existing artifact has a valid opener,
-#      preserve the existing artifact and exit 0.
+#   8. When result is malformed but existing artifact has a valid
+#      opener-plus-closer, preserve the existing artifact and exit 0.
+#   9. When result is malformed AND existing artifact has only an opener (no
+#      closing '---'), do NOT preserve — fall through to parse-error.
+#  10. Whitespace-only blank lines after a code fence are stripped.
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 helper="$repo_root/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py"
@@ -212,5 +215,56 @@ if [[ -f "$out8" ]]; then
   exit 1
 fi
 assert_contains "$workdir/err8.txt" "preserving existing"
+((scenario++))
+
+echo "[$scenario] malformed result + existing artifact missing closing '---' -> parse-error (NOT preserved)"
+in9="$workdir/in9.txt"
+out9="$workdir/out9.txt"
+existing9="$workdir/existing9.txt"
+# Existing artifact has the opener but NO closing '---' — exactly the stale-PASS
+# regression class Hao called out: the engine could otherwise consume an
+# evaluator-invalid file because the previous _has_valid_opening check accepted
+# any first line of '---'.
+cat > "$existing9" <<'EOF'
+---
+verdict: PASS
+notes: stale partial write — missing closing fence
+EOF
+cat > "$in9" <<'EOF'
+Some prose summary instead of frontmatter.
+EOF
+set +e
+run_helper "$in9" "$out9" "$existing9" 2> "$workdir/err9.txt"
+rc=$?
+set -e
+if [[ "$rc" -ne 2 ]]; then
+  echo "scenario $scenario: expected exit code 2 (parse-error, NOT preserve stale partial), got $rc" >&2
+  cat "$workdir/err9.txt" >&2
+  exit 1
+fi
+assert_contains "$out9" "result: parse-error"
+assert_contains "$out9" "agent: test-agent"
+if grep -q "preserving existing" "$workdir/err9.txt"; then
+  echo "scenario $scenario: stderr unexpectedly mentions preservation; existing must not be preserved when malformed" >&2
+  cat "$workdir/err9.txt" >&2
+  exit 1
+fi
+((scenario++))
+
+echo "[$scenario] whitespace-only blank lines after code fence are stripped"
+in10="$workdir/in10.txt"
+out10="$workdir/out10.txt"
+# Fenced artifact where, after the fence, the next line contains only spaces
+# (not a bare newline). `lstrip("\n")` did not handle this; the regex strip
+# must catch it.
+printf '```yaml\n   \n---\nverdict: pass\n---\n```\n' > "$in10"
+run_helper "$in10" "$out10"
+first_line=$(head -n 1 "$out10")
+if [[ "$first_line" != "---" ]]; then
+  echo "scenario $scenario: first line not '---' after fence + whitespace strip (got '$first_line')" >&2
+  cat "$out10" >&2
+  exit 1
+fi
+assert_contains "$out10" "verdict: pass"
 
 echo "claude artifact frontmatter normalization test passed (${scenario} scenarios)"

--- a/scripts/test-claude-artifact-frontmatter.sh
+++ b/scripts/test-claude-artifact-frontmatter.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-claude-artifact-frontmatter.sh — Cover the normalize/validate contract
+# in plugins/.../scripts/normalize_claude_artifact.py.
+#
+# Scenarios:
+#   1. Already-valid raw YAML frontmatter passes through unchanged.
+#   2. ```yaml fenced artifact is unwrapped to raw YAML.
+#   3. Plain ``` fenced artifact is unwrapped.
+#   4. "- ---" list-prefixed first line is de-prefixed.
+#   5. Leading blank lines are stripped.
+#   6. Missing closing "---" fails loud (exit 2) AND writes parse-error YAML.
+#   7. Empty result fails loud.
+#   8. When result is malformed but existing artifact has a valid opener,
+#      preserve the existing artifact and exit 0.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$repo_root/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py"
+
+if [[ ! -f "$helper" ]]; then
+  echo "Error: helper not found at $helper" >&2
+  exit 1
+fi
+
+# shellcheck source=lib/test-helpers.sh
+source "$repo_root/scripts/lib/test-helpers.sh"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/harness-claude-artifact-XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+
+run_helper() {
+  local result_file="$1"
+  local output_file="$2"
+  local existing_file="${3:-}"
+  local args=(--agent test-agent --result-file "$result_file" --output-file "$output_file")
+  if [[ -n "$existing_file" ]]; then
+    args+=(--existing-file "$existing_file")
+  fi
+  python3 "$helper" "${args[@]}"
+}
+
+scenario=1
+echo "[$scenario] valid raw frontmatter passes through unchanged"
+in1="$workdir/in1.txt"
+out1="$workdir/out1.txt"
+cat > "$in1" <<'EOF'
+---
+verdict: pass
+score: 9
+---
+
+Body text here.
+EOF
+run_helper "$in1" "$out1"
+assert_contains "$out1" "verdict: pass"
+assert_contains "$out1" "Body text here."
+diff_count=$(diff "$in1" "$out1" | wc -l | tr -d ' ')
+if [[ "$diff_count" != "0" ]]; then
+  echo "scenario $scenario expected identical content; diff:" >&2
+  diff "$in1" "$out1" >&2 || true
+  exit 1
+fi
+((scenario++))
+
+echo "[$scenario] backtick-yaml fence is unwrapped"
+in2="$workdir/in2.txt"
+out2="$workdir/out2.txt"
+cat > "$in2" <<'EOF'
+```yaml
+---
+verdict: pass
+---
+
+Body
+```
+EOF
+run_helper "$in2" "$out2"
+assert_contains "$out2" "verdict: pass"
+first_line=$(head -n 1 "$out2")
+if [[ "$first_line" != "---" ]]; then
+  echo "scenario $scenario: first line of normalized output is not '---' (got '$first_line')" >&2
+  cat "$out2" >&2
+  exit 1
+fi
+assert_not_contains "$out2" '```yaml'
+assert_not_contains "$out2" '```'
+((scenario++))
+
+echo "[$scenario] plain backtick fence is unwrapped"
+in3="$workdir/in3.txt"
+out3="$workdir/out3.txt"
+cat > "$in3" <<'EOF'
+```
+---
+verdict: review
+---
+
+Notes
+```
+EOF
+run_helper "$in3" "$out3"
+first_line=$(head -n 1 "$out3")
+if [[ "$first_line" != "---" ]]; then
+  echo "scenario $scenario: first line not '---' (got '$first_line')" >&2
+  exit 1
+fi
+assert_contains "$out3" "verdict: review"
+((scenario++))
+
+echo "[$scenario] '- ---' list-prefix first line is de-prefixed"
+in4="$workdir/in4.txt"
+out4="$workdir/out4.txt"
+cat > "$in4" <<'EOF'
+- ---
+verdict: fail
+---
+EOF
+run_helper "$in4" "$out4"
+first_line=$(head -n 1 "$out4")
+if [[ "$first_line" != "---" ]]; then
+  echo "scenario $scenario: first line not '---' (got '$first_line')" >&2
+  cat "$out4" >&2
+  exit 1
+fi
+assert_contains "$out4" "verdict: fail"
+((scenario++))
+
+echo "[$scenario] leading blank lines are stripped"
+in5="$workdir/in5.txt"
+out5="$workdir/out5.txt"
+cat > "$in5" <<'EOF'
+
+
+
+---
+verdict: pass
+---
+EOF
+run_helper "$in5" "$out5"
+first_line=$(head -n 1 "$out5")
+if [[ "$first_line" != "---" ]]; then
+  echo "scenario $scenario: first line not '---' (got '$first_line')" >&2
+  exit 1
+fi
+((scenario++))
+
+echo "[$scenario] missing closing '---' fails loud with parse-error artifact"
+in6="$workdir/in6.txt"
+out6="$workdir/out6.txt"
+cat > "$in6" <<'EOF'
+---
+verdict: pass
+notes: missing closing fence on purpose
+EOF
+set +e
+run_helper "$in6" "$out6" 2> "$workdir/err6.txt"
+rc=$?
+set -e
+if [[ "$rc" -ne 2 ]]; then
+  echo "scenario $scenario: expected exit code 2 (parse-error), got $rc" >&2
+  exit 1
+fi
+assert_contains "$out6" "result: parse-error"
+assert_contains "$out6" "agent: test-agent"
+assert_contains "$out6" "no closing '---' line found"
+assert_contains "$workdir/err6.txt" "malformed artifact"
+((scenario++))
+
+echo "[$scenario] empty input fails loud"
+in7="$workdir/in7.txt"
+out7="$workdir/out7.txt"
+: > "$in7"
+set +e
+run_helper "$in7" "$out7" 2> "$workdir/err7.txt"
+rc=$?
+set -e
+if [[ "$rc" -ne 2 ]]; then
+  echo "scenario $scenario: expected exit code 2 for empty input, got $rc" >&2
+  exit 1
+fi
+assert_contains "$out7" "result: parse-error"
+((scenario++))
+
+echo "[$scenario] malformed result + valid existing artifact -> preserve existing"
+in8="$workdir/in8.txt"
+out8="$workdir/out8.txt"
+existing8="$workdir/existing8.txt"
+cat > "$existing8" <<'EOF'
+---
+verdict: pass
+written_by: agent_directly
+---
+
+Detailed evaluation body.
+EOF
+cat > "$in8" <<'EOF'
+Here is a prose summary instead of frontmatter.
+EOF
+set +e
+run_helper "$in8" "$out8" "$existing8" 2> "$workdir/err8.txt"
+rc=$?
+set -e
+if [[ "$rc" -ne 0 ]]; then
+  echo "scenario $scenario: expected exit code 0 (preserved existing), got $rc" >&2
+  cat "$workdir/err8.txt" >&2
+  exit 1
+fi
+# Output file should not have been touched / created by the helper in preserve mode.
+if [[ -f "$out8" ]]; then
+  echo "scenario $scenario: expected output file to NOT be written when preserving existing" >&2
+  exit 1
+fi
+assert_contains "$workdir/err8.txt" "preserving existing"
+
+echo "claude artifact frontmatter normalization test passed (${scenario} scenarios)"

--- a/scripts/test-claude-artifact-frontmatter.sh
+++ b/scripts/test-claude-artifact-frontmatter.sh
@@ -58,8 +58,7 @@ EOF
 run_helper "$in1" "$out1"
 assert_contains "$out1" "verdict: pass"
 assert_contains "$out1" "Body text here."
-diff_count=$(diff "$in1" "$out1" | wc -l | tr -d ' ')
-if [[ "$diff_count" != "0" ]]; then
+if ! cmp -s "$in1" "$out1"; then
   echo "scenario $scenario expected identical content; diff:" >&2
   diff "$in1" "$out1" >&2 || true
   exit 1

--- a/scripts/test-extract-markdown-verdict-parse-error.sh
+++ b/scripts/test-extract-markdown-verdict-parse-error.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-extract-markdown-verdict-parse-error.sh — Verify that
+# extract_markdown_verdict in harness-engine.sh refuses to read a verdict
+# out of a parse-error artifact, even when the embedded raw agent output
+# contains a `verdict: PASS` line.
+#
+# Regression for the verdict-leak class identified in PR #47 review:
+# normalize_claude_artifact.py wraps malformed agent output (e.g.
+# `---\nverdict: PASS\n` with no closing fence) into a parse-error
+# artifact that preserves the raw bytes for retro. Without the
+# frontmatter short-circuit added to extract_markdown_verdict, the
+# extractor's `(?im)^\s*verdict:\s*PASS` pattern would match the indented
+# embedded line and silently pass the gate.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+engine="$repo_root/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh"
+normalizer="$repo_root/plugins/harness-engineering-skills/skills/harness/scripts/normalize_claude_artifact.py"
+
+if [[ ! -f "$engine" || ! -f "$normalizer" ]]; then
+  echo "Error: harness-engine.sh or normalizer not found" >&2
+  exit 1
+fi
+
+# The engine script unconditionally dispatches a CLI command at the bottom,
+# so we cannot `source` it directly. Pull just the function body out via
+# sed and eval it into this shell. If the function signature in
+# harness-engine.sh changes the eval will fail loudly, which is what we
+# want — this test must stay locked to the production code.
+fn_src=$(sed -n '/^extract_markdown_verdict()/,/^}$/p' "$engine")
+if [[ -z "$fn_src" ]]; then
+  echo "Error: could not extract extract_markdown_verdict() from $engine" >&2
+  exit 1
+fi
+eval "$fn_src"
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/harness-verdict-parse-error-XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+
+scenario=1
+echo "[$scenario] parse-error artifact with embedded 'verdict: PASS' yields NO verdict"
+raw="$workdir/raw.txt"
+artifact="$workdir/parse-err.md"
+# Agent output that violates the contract: opener present, NO closing '---'.
+printf -- '---\nverdict: PASS\nnotes: missing closing fence\n' > "$raw"
+python3 "$normalizer" \
+  --agent harness-evaluator \
+  --result-file "$raw" \
+  --output-file "$artifact" 2>/dev/null \
+  || true  # exit 2 is expected (malformed input)
+
+# Sanity: artifact must exist, be a parse-error, AND still carry the raw
+# 'verdict: PASS' line for retro evidence.
+if [[ ! -f "$artifact" ]]; then
+  echo "scenario $scenario: normalizer did not write artifact at $artifact" >&2
+  exit 1
+fi
+grep -Fq "result: parse-error" "$artifact" || {
+  echo "scenario $scenario: artifact is missing 'result: parse-error' frontmatter" >&2
+  cat "$artifact" >&2
+  exit 1
+}
+grep -Fq "verdict: PASS" "$artifact" || {
+  echo "scenario $scenario: artifact should preserve raw 'verdict: PASS' line as retro evidence" >&2
+  cat "$artifact" >&2
+  exit 1
+}
+
+verdict=$(extract_markdown_verdict "$artifact")
+if [[ -n "$verdict" ]]; then
+  echo "scenario $scenario: parse-error artifact must NOT yield a verdict, got '$verdict'" >&2
+  cat "$artifact" >&2
+  exit 1
+fi
+((scenario++))
+
+echo "[$scenario] well-formed artifact still extracts the verdict"
+good="$workdir/good.md"
+cat > "$good" <<'EOF'
+---
+verdict: PASS
+score: 9
+---
+
+Body.
+EOF
+verdict=$(extract_markdown_verdict "$good")
+if [[ "$verdict" != "PASS" ]]; then
+  echo "scenario $scenario: expected verdict PASS, got '$verdict'" >&2
+  exit 1
+fi
+((scenario++))
+
+echo "[$scenario] artifact with no frontmatter still allows verdict extraction (back-compat)"
+loose="$workdir/loose.md"
+cat > "$loose" <<'EOF'
+Some preamble.
+
+verdict: FAIL
+
+More text.
+EOF
+verdict=$(extract_markdown_verdict "$loose")
+if [[ "$verdict" != "FAIL" ]]; then
+  echo "scenario $scenario: expected verdict FAIL, got '$verdict'" >&2
+  exit 1
+fi
+
+echo "extract_markdown_verdict parse-error regression test passed (${scenario} scenarios)"


### PR DESCRIPTION
## Summary

Closes #41. Centralizes the normalize-and-validate contract for agent
result artifacts so that code-fenced, list-prefixed, or blank-line-prefixed
output no longer lands on disk as malformed files that the harness engine
can't parse.

## Why

Per #41 and the prior Tech Lead triage (issue thread,
2026-05-12), the evaluator-artifact frontmatter parser requires raw `---`
at the artifact's first three characters. Today `claude-agent-invoke.sh`
writes whatever `result_text` the agent emits, with one narrow defensive
case (preserve existing file when the new result is prose). That means:

- a ` ```yaml ` / ` ``` ` code-fenced result lands as `` ```yaml\n---\n...\n``` ``
  and the engine's frontmatter parser fails.
- a `- ---` list-prefixed first line (some agents emit YAML inside a
  bullet) is unreadable as frontmatter.
- a result with an opening `---` but no closing `---` is silently
  written and the engine parses ambiguous bytes.

Each shape is a recurring class per the `watcher-draft-envelope-fix`
retro. Operator workaround (manual normalization, retry) is real cost on
long runs.

## Approach

Two atomic commits:

| Commit | Surface | Effect |
|---|---|---|
| `2fae22d` | new `plugins/.../scripts/normalize_claude_artifact.py` + unit test | Pure helper: strip fences/list-prefix/blanks, validate opener + closer, write parse-error YAML on failure. Importable Python + CLI. |
| `ef716f8` | `parse_claude_json` in `claude-agent-invoke.sh` + e2e test | Route raw `result_text` through the helper; propagate agent name into diagnostics; preserve is_error precedence (exit 1 still wins over normalize-success). |

### Helper contract

`normalize_and_validate(text) -> (normalized, error)`:

1. Strip leading whitespace + blank lines.
2. Strip a leading code fence (` ```yaml `, ` ```markdown `, ` ``` `) and
   the matching trailing fence if present.
3. Strip a leading `- ` from a `- ---` first line (list-item shape).
4. Re-trim leading blank lines.
5. Validate: first non-empty line is exactly `---`; a closing `---` line
   appears later.

On failure:

- if `--existing-file` is provided and contains a valid opener, preserve
  it (backwards-compatible with the `agent wrote artifact directly,
  returned prose` case).
- otherwise write a structured `result: parse-error` YAML to
  `--output-file` (with `agent`, `reason`, `detail`, raw output preserved
  verbatim for retro) and exit `2`.

### Wiring

`parse_claude_json` no longer writes `result_text` directly. It:

1. Extracts `result_text`, `session_id`, `is_error` from the JSON stream
   into tempfiles.
2. Copies any existing `OUTPUT_FILE` to a tempfile (so the normalizer can
   compare against the pre-existing artifact).
3. Calls `normalize_claude_artifact.py --agent "$AGENT_NAME" ...`.
4. If the agent's `is_error=true`, returns 1 (this takes precedence over
   a successful normalize — same as previous behavior).

## Verification

Two new test scripts:

- `scripts/test-claude-artifact-frontmatter.sh` — 8 scenarios covering
  the helper directly (passthrough, two fence flavors, list-prefix,
  leading blanks, missing-closing fail-loud, empty fail-loud, preserve
  existing).
- `scripts/test-claude-agent-invoke-e2e.sh` — 4 scenarios covering
  `claude-agent-invoke.sh` end-to-end with a PATH-stubbed `claude` CLI
  (valid passthrough, fence unwrap, missing-closing fail-loud, is_error
  propagation).

Both pass locally. Sample regression check: existing tests
(`test-spec-format-parallel-group.sh`, `test-assemble-context.sh`,
`check-harness-target-repo.sh`) continue to pass.

## What this PR does NOT do

- It does **not** retrofit the normalizer to codex/gemini-agent-invoke
  counterparts. Those scripts do not exist yet (#34 is the architectural
  decision to introduce them). The helper is shaped so #34 can adopt it
  without re-implementing the contract.
- It does **not** change engine-level frontmatter parsing — that already
  requires raw `---`. The fix is upstream of the parser, at the
  artifact-write step.

## Closes

- #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Robust normalization and validation of agent-produced artifacts with clear parse-error artifacts and non-zero exit for agent-reported errors.
  * Caller now forwards agent identity to normalization to preserve context.

* **Bug Fixes**
  * Prevented extraction of verdicts from artifacts already marked as parse-error.

* **Tests**
  * Added end-to-end and focused regression tests covering normalization, preservation, malformed inputs, and error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/harness-engineering-skills/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->