### PR TITLE
feat(harness): add contract-preservation probe for parser/regex/validator changes

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-evaluator.md
@@ -27,7 +27,7 @@ Be thorough and evidence-based. Every claim must be backed by test output, scree
 ## Focus Areas
 
 - **Tier 1 (deterministic)**: magnitude check, tests, type check, linter, browser verification, API verification
-- **Tier 2 (LLM review)**: edge cases, concurrency, security, performance, logic correctness, goal relevance, **fault-path probe for external-input code paths** (see Key Actions step 4)
+- **Tier 2 (LLM review)**: edge cases, concurrency, security, performance, logic correctness, goal relevance, **fault-path probe for external-input code paths** (see Key Actions step 4), **contract-preservation probe for parser/regex/validator changes** (see Key Actions step 4b)
 
 ## Key Actions
 
@@ -39,6 +39,15 @@ Be thorough and evidence-based. Every claim must be backed by test output, scree
    - An evaluator-led simulation: run the code path with a hand-crafted malformed fixture and document stdout/stderr/exit code in `evaluation.md` under a **"Fault-path probe"** heading.
 
    If the CP has **no** external input (pure computation, compile-time constants), state that explicitly in `evaluation.md` with one line (e.g. `Fault-path probe: N/A — pure computation`) so reviewers see the question was asked and answered. Specifically for atomic-writer patterns (`mktemp` + `mv`), verify the tempfile sits on the same filesystem as the target — a naked `mktemp` (defaults to `$TMPDIR`) produces a cross-fs `mv` that degrades to non-atomic copy+unlink.
+4b. **Contract-preservation probe is mandatory for parser/regex/validator/schema changes.** If the checkpoint modifies any function whose contract includes "must reject input X" or "must accept input Y" (URL validators, regex matchers, grammar parsers, JSON schemas, type guards, security policies, format normalisers), step 4's malformed-input probe is **not sufficient**. The Tier 2 review MUST also include a corpus-based probe documented under a **"Contract-preservation probe"** heading in `evaluation.md`:
+
+   - **Must-reject corpus** — enumerate ≥ 5 inputs the function should still reject after the change. Run the modified code against each. Confirm each is rejected with the expected error mode. At least 2 of the 5 MUST be edge cases the spec did not explicitly mention (e.g. the standard's negative examples, historical bug regressions, adversarial near-miss strings).
+   - **Must-accept corpus** — enumerate ≥ 10 inputs the function should still accept after the change. Run the modified code against each. Confirm each is accepted. The corpus MUST be intentionally diverse beyond what the spec mentions: include characters/forms the relevant standard explicitly permits (RFC, BNF, format spec), legitimate edge cases, and the boundary between "valid" and "invalid". Self-generated "looks reasonable" examples from the Generator's perspective are insufficient — they encode the same prior that produced the patch.
+   - **Mine the upstream test suite first.** Before generating a corpus, search the host repo for existing test files that exercise the modified function (`grep -rn 'URLValidator\|test_url' tests/`). Their existing positive/negative examples are ground truth, not LLM imagination. Cite the test file:line in `evaluation.md` for each corpus entry that came from upstream tests.
+
+   If the CP makes no such change (pure refactor, code organisation, infra config), state that explicitly with one line (e.g. `Contract-preservation probe: N/A — pure refactor`).
+
+   **Why this is non-optional**: cross-model peer review (review-loop with a Codex or Gemini peer) does **not** reliably catch over-restrictive or over-permissive contract changes. Both Claude and Codex share the same prior toward "optimise the positive cases the spec called out", so adding a different-vendor reviewer doesn't change the outcome — the corpus must be explicit at probe time. See `stone16/swe-bench-harness-eval/EXPERIMENT_AB.md` for the empirical evidence (3-instance A/B test, 0/3 flipped despite Codex peer; only the two breakthroughs that DID work resolved instances no public agent solved).
 5. Write evaluation.md per protocol format
 6. Set verdict: PASS / FAIL / REVIEW
 7. **If REVIEW**: classify each review_item with structured fields:


### PR DESCRIPTION
## Summary

Adds a mandatory **contract-preservation probe** to `harness-evaluator`'s Tier 2 review for any checkpoint that modifies a parser, regex, validator, schema, type guard, security policy, or format normaliser. The probe requires the Evaluator to enumerate a **must-reject corpus (≥ 5)** and **must-accept corpus (≥ 10)**, with explicit instruction to mine the upstream test suite for ground-truth corpora rather than relying on LLM-generated examples.

Single file change: `plugins/harness-engineering-skills/agents/harness-evaluator.md` (+10/-1).

## Why

The existing Tier 2 "fault-path probe" (step 4) covers **robustness against malformed input** (invalid JSON, embedded newlines, etc.) but does **not** cover **contract preservation** (what inputs the function should still accept/reject after the change). This is a real, measurable gap.

Evidence comes from a sister repo, [stone16/swe-bench-harness-eval](https://github.com/stone16/swe-bench-harness-eval), where we ran harness on 10 SWE-bench Verified instances. The 3 failures were all parser/regex/validator changes that fell into the same trap:

| Instance | Pattern | What harness's self-generated probe checked | What the hidden grader actually tested |
|---|---|---|---|
| `django__django-10097` | URLValidator regex | 8 cases (3 must-reject + 5 must-accept) | 438 cases (failed 7 + 5 regressions) |
| `astropy__astropy-14369` | CDS grammar parser | 3 positive cases the spec named | 3 hidden tests, including 1 `should-fail` that no longer fails |
| `matplotlib__matplotlib-20676` | SpanSelector axis handling | self-judged positive cases | 2 hidden tests, none passing |

The Generator's self-written `must_accept` corpus had 5 conventional URLs (`http://userid:password@example.com` style). The actual test suite uses RFC-legal forms with `.`, `+`, `%`, `~` in usernames — which the Generator's tightened regex rejected. The Evaluator passed the patch because its narrow self-corpus passed, not because the contract was actually preserved.

Then we ran the **A/B experiment** ([EXPERIMENT_AB.md](https://github.com/stone16/swe-bench-harness-eval/blob/main/EXPERIMENT_AB.md)): re-ran the 3 failures with \`cross_model_review=true\` (Codex peer enabled). **0/3 flipped to PASS.** Cross-model peer changed the patch *strategy* on 2/3 instances (one escalated from a hacky string preprocessor to a proper LALR grammar rewrite) but did not change the *outcome* — both Claude and Codex share the same prior toward optimising spec-mentioned positive cases.

**Conclusion**: peer-review is the wrong layer to fix this. The corpus must be explicit at probe time, mined from the host repo's own test suite when possible.

## Approach

- Augments **step 4** of `## Key Actions` with a new sub-step **4b** ("Contract-preservation probe").
- Adds one cross-reference in `## Focus Areas` so the Tier 2 bullet lists both probes side-by-side.
- Section uses the same prose style as existing step 4 (mandatory wording, explicit N/A clause, evidence heading name).
- Cites the SWE-bench eval repo for empirical evidence inline so future maintainers (and the LLM running as the Evaluator) understand *why* the rule exists, not just *what* it says.

**Design choices:**
- **Why a separate step 4b instead of folding into step 4?** Step 4 is about *robustness* against malformed input. Step 4b is about *contract preservation* under valid input. Different concerns, different probes, different N/A clauses. Keeping them separate makes both rules easier to follow and easier to skip with documented justification.
- **Why ≥5 must-reject / ≥10 must-accept?** The asymmetry reflects the asymmetric failure mode we observed: over-restrictive fixes break many *must-accept* cases (regression), while over-permissive fixes break few *must-reject* cases (one negative test in astropy-14369 was enough). Larger must-accept corpus is the cheap insurance.
- **Why "mine the upstream test suite first"?** This is the load-bearing rule. LLM-generated corpora encode the same prior that produced the patch. Existing test files are ground truth.

**Alternatives rejected:**
- *Add Codex peer requirement* — empirically tested in the A/B run, 0/3 flipped (see EXPERIMENT_AB.md). The bias is shared across vendors.
- *Add a separate sub-agent for negative-case probing* — would inflate cost without changing the underlying ground-truth problem (peer agents have the same training-data bias).
- *Change the spec template to require Must-Reject/Must-Accept lists* — better long-term, but a separate concern at a different layer (Planner, not Evaluator). Intentionally deferred (see Out of Scope).

## How I Tested

This is a prose change to an agent's instruction file; the test is reviewer reading the diff against the existing step 4 conventions.

Verification I ran:

- \`bash -n\` equivalent: the file is markdown, but I confirmed the existing \"4.\" → \"5.\" → \"6.\" numbering is unbroken (inserted as \"4b.\" which markdown will render as a continuation indented under 4 — preserves visual hierarchy of mandatory probes).
- Grepped for existing \"negative\" / \"reject\" / \"fault-path\" / \"regression\" usage across all references files to ensure no terminology collision with existing concepts (\`Verification:\` blocks, \`auto_resolvable\` rejections, etc.). Confirmed no collision.
- Read the new prose alongside the existing fault-path probe; structure matches (mandatory bullet, explicit N/A clause, evidence heading, justifying paragraph).

The empirical evidence for *why this matters* is at:
- Per-instance verdicts: https://github.com/stone16/swe-bench-harness-eval/blob/main/RESULTS.md
- A/B experiment: https://github.com/stone16/swe-bench-harness-eval/blob/main/EXPERIMENT_AB.md
- Raw grader reports: https://github.com/stone16/swe-bench-harness-eval/tree/main/logs/run_evaluation

## Rollback Plan

1. **Maximum blast radius**: zero. This is prose in one agent definition file. Worst case the Evaluator spends extra tokens on a contract-preservation section that turns out to be N/A — no incorrect output, no data integrity risk.
2. **Time-to-rollback**: under one minute. \`git revert <commit>\`.

No data migration, no config change, no schema change. The Evaluator becomes effective the next time it's invoked.

## Out of Scope

- **Spec-template change** to require \`### Must reject\` / \`### Must accept\` lists in checkpoint \`Success Criteria\`. This would shift some of the corpus burden upstream to the Planner. Deferred because (a) it's a different agent, (b) it touches \`planning-protocol.md\` and \`checkpoint-definition.md\` — atomic PR discipline says do that separately, and (c) it's worth doing only after this evaluator-side change proves out in practice.
- **Generator-side prompt** to bias toward minimal-diff contract changes (avoid tightening regexes more than the issue requires). Same atomic-PR rationale.
- **Adding a third sub-agent for negative-case fuzzing.** Empirically rejected: the A/B test showed adding a different-vendor peer doesn't help when both share the bias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Tier 2 review requirements with explicit fault-path probes for external-input code paths.
  * Introduced Contract-preservation probe requirements for functions modifying parser/regex/validator/schema logic, requiring documented must-reject (≥5 inputs with edge cases) and must-accept (≥10 inputs) test corpora.
  * Added guidance for citing upstream test sources in corpus documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/harness-engineering-skills/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->