### PR TITLE
docs(harness): align quick-ref mirror with broadened TDD-T definition

### DIFF
--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -240,9 +240,13 @@ for planners — keep them mirrored.
 - `cross-CP commit count vs TDD sequence contradiction` flags a Success
   Criterion asserting an **exact** commit count `N` (e.g. "N commits land",
   "exactly N commits") combined with `T` checkpoints requiring a Red→Green
-  TDD sequence when `N < 2T + (total_CPs − T)`. Minimum-bound forms ("at
-  least N", "≥ N", "no fewer than N", "minimum N") are exempt — the lower
-  bound is satisfied by the actual commit count. Source: issue #29.
+  TDD sequence when `N < 2T + (total_CPs − T)`. A checkpoint counts toward
+  `T` if its acceptance criteria require a Red→Green sequence **or** its
+  `Type` is `backend`, `infrastructure`, or `fullstack` (per Generator
+  Principle 2 + full-verify gate's TDD Commit Sequence entry).
+  Minimum-bound forms ("at least N", "≥ N", "no fewer than N",
+  "minimum N") are exempt — the lower bound is satisfied by the actual
+  commit count. Source: issue #29.
 
 ---
 


### PR DESCRIPTION
## Summary

Post-merge coherence pass after [#45](https://github.com/stone16/harness-engineering-skills/pull/45), [#46](https://github.com/stone16/harness-engineering-skills/pull/46), and [#47](https://github.com/stone16/harness-engineering-skills/pull/47) landed earlier today. PR #46 broadened the spec-evaluator's `cross-CP commit count vs TDD sequence contradiction` rule so `T` includes checkpoints whose `Type ∈ {backend, infrastructure, fullstack}` (because those Types mandate TDD by protocol, even when acceptance bullets don't restate it). The `protocol-quick-ref.md` mirror entry still described the narrower acceptance-text-only form — a reader using the quick-ref as the source of truth would compute a different `T` than the spec-evaluator does.

This PR updates only the mirror text to match. No rule behavior change.

## Why

Coherence between the spec-evaluator agent file and the protocol quick reference. Both are read independently — when they drift, downstream Generator/Planner sessions get different answers depending on which one they consult.

## Scope

One file touched, one paragraph rewritten:

- `plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md` — extend the `T` definition in the cross-CP commit-count mirror and cite the underlying sources (Generator Principle 2 + full-verify gate's TDD Commit Sequence entry).

## Test plan

- [x] No code change — `git diff --stat` shows only `.md`.
- [x] No new `TODO`/`FIXME` markers in touched files.
- [x] `bash scripts/test-spec-evaluator-parallel-group.sh` — passes.
- [x] `bash scripts/check-parallel-cohort-rules.sh` — passes.
- [x] `bash scripts/test-claude-artifact-frontmatter.sh` — passes.
- [x] `bash scripts/test-claude-agent-invoke-e2e.sh` — passes.

## Rollback plan

`git revert <merge-sha>` — single-file docs change, zero blast radius.