### PR TITLE
fix(harness): engine coverage-gate + preflight scoped-staging (#35, #36)

### DIFF
--- a/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
@@ -1769,16 +1769,37 @@ cmd_pass_full_verify() {
   fi
 
   # ── Coverage gate: enforce threshold for backend/infra/fullstack tasks ──
+  #
+  # Detection precedence (issue #35):
+  #   1. Count anchored `- Type: <value>` lines per checkpoint (canonical
+  #      shape + the `**Type**` compat shape from protocol-quick-ref).
+  #      Broad-grep keyword scans against spec prose are too noisy — a spec
+  #      saying "preserve all existing backend wiring" must not trip the gate.
+  #   2. The gate enforces ONLY when at least one CP has Type backend,
+  #      infrastructure, or fullstack. Frontend-only tasks are exempt.
+  #
+  # Null-coverage handling (issue #35):
+  #   - `coverage_percent: null` (or missing/empty) on a frontend-only task
+  #     is the canonical exempt form — pass through silently.
+  #   - `null`/missing/empty on a non-frontend-only task is a hard fail.
+  #   - Non-numeric non-null values are a hard fail (would crash arithmetic).
   local spec_file
   spec_file="$(harness_dir)/spec.md"
-  local has_backend_work="false"
+  local backend_cp_count=0
+  local total_cp_count=0
+  local frontend_cp_count=0
   if [[ -f "$spec_file" ]]; then
-    if grep -qi 'Type.*backend\|Type.*infrastructure\|Type.*fullstack' "$spec_file"; then
-      has_backend_work="true"
-    fi
+    # Canonical and compat Type shapes; bullet-anchored to avoid prose matches.
+    backend_cp_count=$(grep -cE '^- (\*\*)?Type(\*\*)?:[[:space:]]*(backend|infrastructure|fullstack)\b' "$spec_file" 2>/dev/null || echo 0)
+    frontend_cp_count=$(grep -cE '^- (\*\*)?Type(\*\*)?:[[:space:]]*frontend\b' "$spec_file" 2>/dev/null || echo 0)
+    total_cp_count=$(grep -cE '^### Checkpoint [0-9]+:' "$spec_file" 2>/dev/null || echo 0)
+  fi
+  local frontend_only="false"
+  if (( total_cp_count > 0 && frontend_cp_count == total_cp_count )); then
+    frontend_only="true"
   fi
 
-  if [[ "$has_backend_work" == "true" ]]; then
+  if (( backend_cp_count > 0 )); then
     # Read coverage_threshold from config (default 85)
     local threshold="$DEFAULT_COVERAGE_THRESHOLD"
     local config_file=".harness/config.json"
@@ -1792,10 +1813,18 @@ cmd_pass_full_verify() {
     local coverage
     coverage=$(grep -m1 '^coverage_percent:' "$report" 2>/dev/null | sed 's/coverage_percent:[[:space:]]*//' | tr -d '%')
 
-    if [[ -z "$coverage" ]]; then
+    if [[ -z "$coverage" || "$coverage" == "null" || "$coverage" == "N/A" ]]; then
       echo "PHASE_BLOCKED" >&2
-      echo "REASON=Backend/infra/fullstack work detected but verification-report.md missing coverage_percent field" >&2
-      echo "NEXT_STEP=Re-run full-verify with coverage reporting enabled. Add coverage_percent: <N> to frontmatter." >&2
+      echo "REASON=Backend/infra/fullstack work detected but verification-report.md coverage_percent is '${coverage:-<missing>}' — measured value required" >&2
+      echo "NEXT_STEP=Re-run full-verify with coverage reporting enabled. Add coverage_percent: <N> to frontmatter (N/A is only valid for frontend-only tasks)." >&2
+      exit 1
+    fi
+
+    # Numeric format check (guards arithmetic against non-numeric input)
+    if ! [[ "$coverage" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+      echo "PHASE_BLOCKED" >&2
+      echo "REASON=coverage_percent value '${coverage}' is not numeric (expected a number or 'N/A' on frontend-only tasks)" >&2
+      echo "NEXT_STEP=Set coverage_percent to a measured number (e.g. 87.5) in verification-report.md frontmatter" >&2
       exit 1
     fi
 

--- a/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
+++ b/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh
@@ -1790,9 +1790,19 @@ cmd_pass_full_verify() {
   local frontend_cp_count=0
   if [[ -f "$spec_file" ]]; then
     # Canonical and compat Type shapes; bullet-anchored to avoid prose matches.
-    backend_cp_count=$(grep -cE '^- (\*\*)?Type(\*\*)?:[[:space:]]*(backend|infrastructure|fullstack)\b' "$spec_file" 2>/dev/null || echo 0)
-    frontend_cp_count=$(grep -cE '^- (\*\*)?Type(\*\*)?:[[:space:]]*frontend\b' "$spec_file" 2>/dev/null || echo 0)
-    total_cp_count=$(grep -cE '^### Checkpoint [0-9]+:' "$spec_file" 2>/dev/null || echo 0)
+    # Case-insensitive so a `- Type: Backend` typo still classifies the CP
+    # rather than silently falling through both branches.
+    # Use `|| true` (not `|| echo 0`) — `grep -c` already prints "0" on no
+    # matches, so `|| echo 0` would produce a two-line `"0\n0"` value that
+    # triggers `((…))` syntax errors and silently treats the count as zero.
+    backend_cp_count=$(grep -ciE '^- (\*\*)?Type(\*\*)?:[[:space:]]*(backend|infrastructure|fullstack)\b' "$spec_file" 2>/dev/null || true)
+    frontend_cp_count=$(grep -ciE '^- (\*\*)?Type(\*\*)?:[[:space:]]*frontend\b' "$spec_file" 2>/dev/null || true)
+    total_cp_count=$(grep -cE '^### Checkpoint [0-9]+:' "$spec_file" 2>/dev/null || true)
+    # Guard against the edge case where grep exits before printing (e.g. file
+    # unreadable) — leave the value at 0 rather than empty so `((…))` is safe.
+    backend_cp_count=${backend_cp_count:-0}
+    frontend_cp_count=${frontend_cp_count:-0}
+    total_cp_count=${total_cp_count:-0}
   fi
   local frontend_only="false"
   if (( total_cp_count > 0 && frontend_cp_count == total_cp_count )); then

--- a/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/review-loop/SKILL.md
@@ -214,10 +214,19 @@ For each accepted finding:
 ### Step 2.3: Checkpoint commit
 
 ```bash
-git add -A && git commit -m "review-loop: changes from round {N}" --allow-empty
+git commit -am "review-loop: changes from round {N}" --allow-empty
 ```
 
-The `--allow-empty` flag ensures rounds where the host agent only rejects findings (no code changes) don't fail.
+**Scoped, not broad** (issue #36): `git commit -am` stages
+tracked-modified files only. Do NOT use `git add -A` — it sweeps every
+untracked file in the workspace (including `.harness/` scratch from
+prior or parallel tasks) onto the feature branch, poisoning the diff
+the peer reviews. If your round's accepted-fix work creates a genuinely
+new file that belongs on the branch, `git add <path>` it explicitly
+before this checkpoint commit.
+
+The `--allow-empty` flag ensures rounds where the host agent only
+rejects findings (no code changes) don't fail.
 
 ### Step 2.4: Update rounds.json
 

--- a/plugins/harness-engineering-skills/skills/review-loop/scripts/preflight.sh
+++ b/plugins/harness-engineering-skills/skills/review-loop/scripts/preflight.sh
@@ -206,9 +206,37 @@ cat > "$SESSION_DIR/rounds.json" << ENDJSON
 }
 ENDJSON
 
-# --- Step 0.8: Checkpoint commit ---
+# --- Step 0.8: Checkpoint commit (scoped, not broad) ---
+#
+# Issue #36: `git add -A` sweeps every untracked file in the workspace
+# onto the feature branch, including .harness/ scratch from prior or
+# parallel tasks. The peer reviews TARGET_FILES (tracked diff) but the
+# branch under review can carry far more — defeating the cross-model
+# gate. Default the checkpoint commit to TRACKED-MODIFIED only via
+# `git commit -am`; the .gitignore line we may have added in step 0.6
+# is staged explicitly. Untracked files the operator genuinely wants
+# on the branch must be `git add`-ed before invoking review-loop.
+#
+# As a courtesy, list any untracked workspace files (excluding the
+# known scratch dirs) on stderr so the operator notices what is being
+# left behind.
 if [[ "$READ_ONLY" != "true" ]]; then
-  git add -A && git commit -m "review-loop: checkpoint before round 1" --allow-empty 2>/dev/null
+  if [[ "$GITIGNORE_MODIFIED" == "true" ]]; then
+    git add .gitignore 2>/dev/null || true
+  fi
+  # Surface unexpected untracked paths so the operator sees what is
+  # being intentionally left out of the checkpoint commit.
+  UNTRACKED_OUTSIDE_SCRATCH="$(git ls-files --others --exclude-standard 2>/dev/null \
+    | grep -Ev '^(\.harness/|\.review-loop/|nexus_data/|tmp/|node_modules/)' || true)"
+  if [[ -n "$UNTRACKED_OUTSIDE_SCRATCH" ]]; then
+    echo "Warning: untracked files in workspace are NOT in the checkpoint commit (peer will not see them):" >&2
+    echo "$UNTRACKED_OUTSIDE_SCRATCH" | sed 's/^/  /' >&2
+    echo "  → If any belong on the feature branch, run 'git add <path>' before re-invoking review-loop." >&2
+  fi
+  # -a stages tracked-modified files only. --allow-empty lets us mark a
+  # checkpoint when there is nothing new to stage.
+  git commit -am "review-loop: checkpoint before round 1" --allow-empty 2>/dev/null \
+    || git commit -m "review-loop: checkpoint before round 1" --allow-empty 2>/dev/null
 elif [[ "$GITIGNORE_MODIFIED" == "true" ]]; then
   # In read-only mode, still commit the gitignore change to avoid leaving dirty state
   git add .gitignore && git commit -m "review-loop: add .review-loop/ to gitignore" --allow-empty 2>/dev/null

--- a/scripts/test-engine-coverage-gate.sh
+++ b/scripts/test-engine-coverage-gate.sh
@@ -247,4 +247,44 @@ write_report "$task_dir/full-verify" "coverage_percent: null"
 out="$(run_pass_full_verify "$repo")"
 assert_phase_blocked_with "$out" "coverage_percent is 'null'"
 
+# ── Scenario 9: case-typo `- Type: Backend` + null coverage → FAIL (case-insensitive) ──
+# Regression for codex-connector PR #52 review. Strict-lowercase regex would
+# not match `Backend`, both backend_cp_count and frontend_cp_count would be 0,
+# frontend_only would be false, and the gate's `if` would not fire. Combined
+# with the `|| echo 0` multi-line bug, this silently skipped enforcement.
+scenario "Type:Backend (capital B typo) + null coverage → PHASE_BLOCKED (case-insensitive)"
+repo="$tmpdir/s9"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Type: Backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: null"
+out="$(run_pass_full_verify "$repo")"
+assert_phase_blocked_with "$out" "coverage_percent is 'null'"
+
+# ── Scenario 10: zero Type: lines must not trigger ((…)) syntax errors ──
+# Regression for codex-connector PR #52: a spec with NO Type lines previously
+# made backend_cp_count="0\n0" via grep+`|| echo 0`, which triggered a `((…))`
+# syntax error AND silently treated the count as zero. After the fix the
+# count is a clean 0 and arithmetic is safe.
+scenario "spec with zero Type: lines does not leak ((…)) syntax errors to stderr"
+repo="$tmpdir/s10"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: null"
+stderr_file="$tmpdir/s10.stderr"
+(cd "$repo" && "$engine" pass-full-verify --task-id cov-gate-test 2>"$stderr_file" >/dev/null) || true
+if grep -Fq 'syntax error in expression' "$stderr_file"; then
+  echo "FAIL: bash arithmetic syntax error leaked to stderr — multi-line count regression?" >&2
+  cat "$stderr_file" >&2
+  exit 1
+fi
+
 echo "pass-full-verify coverage gate test passed ($scenarios_run scenarios)"

--- a/scripts/test-engine-coverage-gate.sh
+++ b/scripts/test-engine-coverage-gate.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for issue #35: pass-full-verify coverage gate must
+# (a) use anchored `^- Type:` parsing instead of broad-grep against spec prose,
+# (b) handle null / N/A / missing / non-numeric coverage_percent without
+#     crashing bash arithmetic, and
+# (c) exempt frontend-only tasks from the gate even when prose mentions
+#     "backend" or "infrastructure".
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+engine="$repo_root/plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+scenarios_run=0
+
+write_spec() {
+  local task_dir="$1"
+  local checkpoints_block="$2"
+  cat > "$task_dir/spec.md" <<SPEC
+---
+task_id: cov-gate-test
+title: coverage gate fixture
+version: 1
+status: approved
+branch: test
+created: 2026-05-23
+updated: 2026-05-23
+---
+
+## Goal
+
+$checkpoints_block
+SPEC
+}
+
+write_report() {
+  local fv_dir="$1"
+  local coverage_line="$2"
+  mkdir -p "$fv_dir/iter-1"
+  cat > "$fv_dir/iter-1/verification-report.md" <<REPORT
+---
+task_id: cov-gate-test
+iteration: 1
+verdict: PASS
+hard_failures: 0
+soft_warnings: 0
+$coverage_line
+---
+
+# Verification Report
+REPORT
+}
+
+setup_full_verify_state() {
+  local repo="$1"
+  local task="cov-gate-test"
+  git init -q -b main "$repo"
+  (
+    cd "$repo"
+    git config user.email "test@example.com"
+    git config user.name "Coverage Gate Test"
+    echo root > README.md
+    git add README.md
+    git commit -q -m "initial"
+  )
+  local task_dir="$repo/.harness/$task"
+  mkdir -p "$task_dir/full-verify"
+  local baseline
+  baseline="$(cd "$repo" && git rev-parse HEAD)"
+  cat > "$task_dir/git-state.json" <<JSON
+{
+  "task_id": "$task",
+  "task_start_sha": "$baseline",
+  "phase": "full-verify",
+  "checkpoints": {},
+  "e2e_baseline_sha": "",
+  "e2e_final_sha": "",
+  "review_loop_status": "",
+  "review_loop_session_id": "",
+  "review_loop_summary_file": "",
+  "review_loop_rounds_file": "",
+  "full_verify_baseline_sha": "$baseline",
+  "full_verify_final_sha": "",
+  "full_verify_status": "",
+  "pr_url": ""
+}
+JSON
+  echo "$task_dir"
+}
+
+run_pass_full_verify() {
+  local repo="$1"
+  (cd "$repo" && "$engine" pass-full-verify --task-id cov-gate-test 2>&1; echo "EXIT=$?")
+}
+
+scenario() {
+  local desc="$1"
+  scenarios_run=$((scenarios_run + 1))
+  printf '[%d] %s\n' "$scenarios_run" "$desc"
+}
+
+assert_phase_blocked_with() {
+  local out="$1"
+  local needle="$2"
+  if ! grep -Fq -- "$needle" <<<"$out"; then
+    echo "FAIL: expected PHASE_BLOCKED reason to contain: $needle" >&2
+    echo "actual:" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+  grep -q '^EXIT=1$' <<<"$out" || {
+    echo "FAIL: expected exit 1 (PHASE_BLOCKED), got:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+}
+
+assert_passed() {
+  local out="$1"
+  grep -q '^EXIT=0$' <<<"$out" || {
+    echo "FAIL: expected exit 0 (PASS), got:" >&2
+    echo "$out" >&2
+    exit 1
+  }
+}
+
+# ── Scenario 1: backend CP + null coverage → FAIL (regression for arithmetic crash) ──
+scenario "backend CP + coverage_percent: null → PHASE_BLOCKED with explicit reason (no crash)"
+repo="$tmpdir/s1"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Type: backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: null"
+out="$(run_pass_full_verify "$repo")"
+assert_phase_blocked_with "$out" "coverage_percent is 'null'"
+
+# ── Scenario 2: backend CP + missing coverage_percent → FAIL ──
+scenario "backend CP + missing coverage_percent → PHASE_BLOCKED"
+repo="$tmpdir/s2"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Type: backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" ""
+out="$(run_pass_full_verify "$repo")"
+assert_phase_blocked_with "$out" "coverage_percent is '<missing>'"
+
+# ── Scenario 3: backend CP + non-numeric coverage → FAIL (no arithmetic crash) ──
+scenario "backend CP + coverage_percent: abc → PHASE_BLOCKED for non-numeric"
+repo="$tmpdir/s3"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Type: backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: abc"
+out="$(run_pass_full_verify "$repo")"
+assert_phase_blocked_with "$out" "is not numeric"
+
+# ── Scenario 4: frontend-only CP + null coverage → PASS (frontend-only exemption) ──
+scenario "every CP is Type:frontend + coverage_percent: null → PASS (exemption)"
+repo="$tmpdir/s4"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: ui-button
+- Type: frontend
+- Scope: x
+- Acceptance criteria: y
+
+### Checkpoint 02: ui-nav
+- Type: frontend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: null"
+out="$(run_pass_full_verify "$repo")"
+assert_passed "$out"
+
+# ── Scenario 5: frontend-only CP but prose mentions backend → PASS (anchored parsing) ──
+# Regression for broad-grep false-positive: "preserve all existing backend wiring"
+# previously tripped the gate because grep matched "Type" + "backend" across the line.
+scenario "frontend-only CPs + prose mentions backend → PASS (anchored Type parsing)"
+repo="$tmpdir/s5"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+Note: the Type-based dispatch should preserve all existing backend wiring even after refactor.
+
+### Checkpoint 01: ui
+- Type: frontend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: null"
+out="$(run_pass_full_verify "$repo")"
+assert_passed "$out"
+
+# ── Scenario 6: backend CP + 87% coverage → PASS (happy path with threshold 85) ──
+scenario "backend CP + coverage_percent: 87 → PASS (above default threshold 85)"
+repo="$tmpdir/s6"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Type: backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: 87"
+out="$(run_pass_full_verify "$repo")"
+assert_passed "$out"
+
+# ── Scenario 7: backend CP + 70% coverage → FAIL (below threshold) ──
+scenario "backend CP + coverage_percent: 70 → PHASE_BLOCKED below threshold"
+repo="$tmpdir/s7"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- Type: backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: 70"
+out="$(run_pass_full_verify "$repo")"
+assert_phase_blocked_with "$out" "below threshold 85"
+
+# ── Scenario 8: compat **Type** decorated form on backend CP → still detected ──
+scenario "backend CP using compat decorated '- **Type**: backend' shape → gate still enforces"
+repo="$tmpdir/s8"
+task_dir="$(setup_full_verify_state "$repo")"
+write_spec "$task_dir" "
+### Checkpoint 01: api
+- **Type**: backend
+- Scope: x
+- Acceptance criteria: y
+"
+write_report "$task_dir/full-verify" "coverage_percent: null"
+out="$(run_pass_full_verify "$repo")"
+assert_phase_blocked_with "$out" "coverage_percent is 'null'"
+
+echo "pass-full-verify coverage gate test passed ($scenarios_run scenarios)"

--- a/scripts/test-preflight-scoped-staging.sh
+++ b/scripts/test-preflight-scoped-staging.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for issue #36: review-loop preflight.sh checkpoint commit
+# must NOT use `git add -A` because that sweeps cross-task .harness/ scratch
+# and any other untracked workspace junk onto the feature branch under
+# review, defeating the peer-review scope.
+#
+# This test creates a workspace with:
+#   - A tracked file modified since last commit (in scope, should commit)
+#   - An untracked file under .harness/some-other-task/ (out of scope,
+#     must NOT commit — that's the bug the fix addresses)
+#   - An untracked file at workspace root (out of scope, must NOT commit,
+#     but operator should see a warning naming it)
+#
+# Asserts:
+#   - The checkpoint commit contains only the tracked-modified change.
+#   - The .harness/ scratch is still untracked after preflight.
+#   - stderr carries a warning naming the root-level untracked file.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+preflight="$repo_root/plugins/harness-engineering-skills/skills/review-loop/scripts/preflight.sh"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+# Stub a fake `codex` CLI so preflight doesn't bail on "peer not found".
+fake_bin="$tmpdir/bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/codex" <<'STUB'
+#!/usr/bin/env bash
+echo "fake codex called: $*"
+STUB
+chmod +x "$fake_bin/codex"
+export PATH="$fake_bin:$PATH"
+
+scenarios_run=0
+scenario() {
+  scenarios_run=$((scenarios_run + 1))
+  printf '[%d] %s\n' "$scenarios_run" "$1"
+}
+
+assert_no_match_in_commit() {
+  local pattern="$1"
+  if git -C "$repo" log -1 --name-only --pretty=format: | grep -Fq -- "$pattern"; then
+    echo "FAIL: checkpoint commit unexpectedly contains '$pattern':" >&2
+    git -C "$repo" log -1 --name-only --pretty=format: >&2
+    exit 1
+  fi
+}
+
+assert_match_in_commit() {
+  local pattern="$1"
+  if ! git -C "$repo" log -1 --name-only --pretty=format: | grep -Fq -- "$pattern"; then
+    echo "FAIL: checkpoint commit missing expected '$pattern':" >&2
+    git -C "$repo" log -1 --name-only --pretty=format: >&2
+    exit 1
+  fi
+}
+
+assert_path_still_untracked() {
+  local path="$1"
+  if ! git -C "$repo" ls-files --others --exclude-standard | grep -Fxq -- "$path"; then
+    echo "FAIL: expected '$path' to still be untracked after preflight" >&2
+    git -C "$repo" status --short >&2
+    exit 1
+  fi
+}
+
+scenario "preflight commits tracked-modified only; cross-task .harness/ scratch is left untracked"
+repo="$tmpdir/repo"
+origin="$tmpdir/origin.git"
+git init -q --bare "$origin"
+git clone -q "$origin" "$repo"
+(
+  cd "$repo"
+  git checkout -q -b feat/branch
+  git config user.email "test@example.com"
+  git config user.name "Preflight Test"
+  echo "v1" > tracked.txt
+  git add tracked.txt
+  git commit -q -m "initial"
+  git push -q -u origin feat/branch
+  # ── Modify a tracked file (should land in checkpoint commit) ──
+  echo "v2" > tracked.txt
+  # ── Untracked harness scratch from a different task (should NOT land) ──
+  mkdir -p .harness/some-other-task/checkpoints/cp01/iter-1
+  echo "scratch" > .harness/some-other-task/checkpoints/cp01/iter-1/output-summary.md
+  # ── Untracked root-level file (should NOT land; should warn) ──
+  echo "leftover" > extra.txt
+)
+
+stderr_file="$tmpdir/preflight.stderr"
+(
+  cd "$repo"
+  "$preflight" --peer codex --max-rounds 1 --scope diff 2>"$stderr_file" >/dev/null
+)
+
+# Tracked-modified file is in the checkpoint commit
+assert_match_in_commit "tracked.txt"
+# Harness scratch is NOT in the commit and is still untracked
+assert_no_match_in_commit ".harness/some-other-task/checkpoints/cp01/iter-1/output-summary.md"
+assert_path_still_untracked ".harness/some-other-task/checkpoints/cp01/iter-1/output-summary.md"
+# Root-level untracked file is NOT in the commit and is still untracked
+assert_no_match_in_commit "extra.txt"
+assert_path_still_untracked "extra.txt"
+# Operator saw a warning naming the root-level untracked file
+if ! grep -Fq "extra.txt" "$stderr_file"; then
+  echo "FAIL: expected stderr to warn about 'extra.txt'; got:" >&2
+  cat "$stderr_file" >&2
+  exit 1
+fi
+# The scratch path should NOT appear in the warning (it's in the excluded set)
+if grep -Fq ".harness/some-other-task" "$stderr_file"; then
+  echo "FAIL: stderr should not name excluded .harness/ scratch:" >&2
+  cat "$stderr_file" >&2
+  exit 1
+fi
+
+scenario "preflight on a clean workspace produces an --allow-empty checkpoint commit"
+repo="$tmpdir/repo2"
+origin="$tmpdir/origin2.git"
+git init -q --bare "$origin"
+git clone -q "$origin" "$repo"
+(
+  cd "$repo"
+  git checkout -q -b feat/branch2
+  git config user.email "test@example.com"
+  git config user.name "Preflight Test"
+  echo "v1" > tracked.txt
+  git add tracked.txt
+  git commit -q -m "initial"
+  echo "v2" > tracked.txt  # need a diff so scope=diff resolves
+  git add tracked.txt
+  git commit -q -m "round-baseline"
+  git push -q -u origin feat/branch2
+  # Make a small tracked change so preflight finds local-diff scope
+  echo "v3" > tracked.txt
+)
+
+(
+  cd "$repo"
+  "$preflight" --peer codex --max-rounds 1 --scope diff 2>/dev/null >/dev/null
+)
+
+# Checkpoint commit exists at HEAD with the expected message
+last_msg="$(git -C "$repo" log -1 --pretty=%s)"
+if [[ "$last_msg" != "review-loop: checkpoint before round 1" ]]; then
+  echo "FAIL: expected last commit message 'review-loop: checkpoint before round 1', got '$last_msg'" >&2
+  exit 1
+fi
+
+echo "preflight scoped-staging test passed ($scenarios_run scenarios)"


### PR DESCRIPTION
## Summary

Two production bash bugs in the harness, fixed as atomic commits in one PR:

- **#35** — `pass-full-verify` coverage gate misclassified frontend-only tasks (broad-grep) AND crashed bash arithmetic on `coverage_percent: null` (no string coercion guard).
- **#36** — `review-loop` preflight used `git add -A` for the checkpoint commit, sweeping cross-task `.harness/` scratch onto the feature branch and poisoning the peer-reviewed diff.

Both have detailed repro paths in their issue bodies; both shipped with focused fixture tests.

## #35 — Anchored Type parsing + null-safe coverage gate

Two compounding bugs in `cmd_pass_full_verify` at `harness-engine.sh:1771`:

1. **Broad-grep false positive**. `grep -qi 'Type.*backend\|Type.*infrastructure\|Type.*fullstack'` matched "Type" + "backend" anywhere on the same line. A spec saying "the Type-based dispatch should preserve all existing backend wiring" tripped the gate on frontend-only checkpoints.
2. **Null/N/A arithmetic crash**. `[[ "$cov_int" -lt "$threshold" ]]` errors when `cov_int="null"` ("integer expression expected") and aborts under `set -u`.

Fix: replace the broad-grep with bullet-anchored `^- (\*\*)?Type(\*\*)?:[[:space:]]*(backend|infrastructure|fullstack)\b` matching, count total CPs via `^### Checkpoint [0-9]+:`, and treat every-CP-is-frontend as the canonical exemption. Explicitly handle null / N/A / empty / non-numeric coverage_percent with structured PHASE_BLOCKED messages so reviewers see the format problem instead of a crash trace.

The `(\*\*)?` envelope follows the parser pattern codified in `protocol-quick-ref.md` § Engine parser patterns (issue #40) — `- **Type**: backend` is still detected.

## #36 — Scoped preflight checkpoint commit, no broad `git add -A`

`TARGET_FILES` (what the peer reviews) is built from `git diff` — tracked-modified files only. But the checkpoint commit used `git add -A`, which swept every untracked file in the workspace onto the feature branch including `.harness/<other-task-id>/checkpoints/.../iter-*/` scratch from prior or parallel tasks. The branch under review carried far more than the peer ever saw.

Fix is minimal: use `git commit -am` (stages tracked-modified only), explicitly stage any `.gitignore` change from step 0.6, and emit a courtesy stderr warning listing untracked workspace files (excluding well-known scratch dirs). The SKILL.md §Step 2.3 doc is updated to mirror the same guidance for the per-round commit pattern.

**Deliberately out of scope**: the issue body suggested a structured abort + `--include-untracked-paths` opt-in flag. That adds new-flag complexity for behavior the minimal fix does not need. Stricter enforcement is a follow-up if review surfaces a need.

## Scope

| File | Change |
|---|---|
| `plugins/harness-engineering-skills/skills/harness/scripts/harness-engine.sh` | coverage gate rewrite (issue #35) |
| `plugins/harness-engineering-skills/skills/review-loop/scripts/preflight.sh` | scoped checkpoint commit (issue #36) |
| `plugins/harness-engineering-skills/skills/review-loop/SKILL.md` | doc mirror of scoped-commit guidance |
| `scripts/test-engine-coverage-gate.sh` | new — 8 regression scenarios |
| `scripts/test-preflight-scoped-staging.sh` | new — 2 regression scenarios |

Two atomic commits:

- `918de6d` — #35 (engine coverage gate + fixture test)
- `9b27c76` — #36 (preflight scoped staging + fixture test)

## Test plan

- [x] `bash scripts/test-engine-coverage-gate.sh` — 8/8 pass (null-on-backend → fail, null-on-frontend-only → pass, prose-only "backend" mention → pass, non-numeric → fail, compat `**Type**` still detected, happy path, below-threshold fail).
- [x] `bash scripts/test-preflight-scoped-staging.sh` — 2/2 pass (cross-task scratch left untracked + stray root file warned; clean workspace produces allow-empty checkpoint).
- [x] Existing tests still pass: `test-spec-evaluator-parallel-group.sh`, `check-parallel-cohort-rules.sh`, `test-claude-artifact-frontmatter.sh`, `test-claude-agent-invoke-e2e.sh`.

## Rollback plan

`git revert <merge-sha>` — both commits are self-contained. The fixture tests are net-new and independent. No data migration, no deploy step.