### PR TITLE
feat(harness): magnitude advisory path for intentional scope overruns (#27)

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-evaluator.md
+++ b/plugins/harness-engineering-skills/agents/harness-evaluator.md
@@ -35,7 +35,11 @@ Be thorough and evidence-based. Every claim must be backed by test output, scree
 
 1. Read the checkpoint spec (acceptance criteria) and Generator's output-summary.md
 2. Review the git diff to understand what changed
-3. **Tier 1**: First run magnitude check — read `effort_estimate` from context.md frontmatter, compute actual insertions and file count from `git diff --stat`, compare against 3× threshold (S=150/9, M=450/24, L=900/36). If exceeded → set REVIEW with goal-relevance focus. Then run tests, type check, linter. For frontend: use agent-browser to render and interact. For backend: call API endpoints and verify responses. Save all outputs to evidence/
+3. **Tier 1**: First run magnitude check — read `effort_estimate` from context.md frontmatter, compute actual insertions and file count from `git diff --stat`, compare against 3× threshold (S=150/9, M=450/24, L=900/36). If exceeded, run the **goal-relevance audit**: walk every changed file group and decide whether each maps to this checkpoint's spec scope. Two outcomes:
+   - **All file groups map to spec AND** the output-summary.md contains a `## Size Waiver Rationale` section (or the spec explicitly documents merged/intentional scope) → emit `verdict: PASS` with `magnitude_advisory: true` in evaluation.md frontmatter. Record the actual vs threshold numbers and the waiver rationale under a `## Magnitude Advisory` section in evaluation.md so the operator sees the overrun was reviewed and accepted. Issue #27.
+   - **Off-scope file groups exist OR no waiver rationale is present** → keep `verdict: REVIEW` with goal-relevance focus (current behaviour).
+
+   Then run tests, type check, linter. For frontend: use agent-browser to render and interact. For backend: call API endpoints and verify responses. Save all outputs to evidence/
 4. **Tier 2**: Deep code review — edge cases, race conditions, security, performance, logic correctness vs spec intent. **Fault-path probe is mandatory** if the CP's code reads or parses external input (files, env vars, stdin, arguments into `jq`/`sed`/`awk`/`python`/bash parameter expansion). Include one of:
    - A CP-suite test that feeds malformed input (invalid JSON, non-numeric version, trailing backslash, embedded newline) and asserts well-defined behaviour (error message + exit code, or graceful-degrade path); OR
    - An evaluator-led simulation: run the code path with a hand-crafted malformed fixture; document stdout/stderr/exit code in `evaluation.md` under a **"Fault-path probe"** heading.

--- a/plugins/harness-engineering-skills/agents/harness-generator.md
+++ b/plugins/harness-engineering-skills/agents/harness-generator.md
@@ -85,6 +85,18 @@ fields in the YAML frontmatter when you can determine them (see
 Fields are optional and engine-ignored. Omit any value you cannot determine —
 never fabricate a placeholder.
 
+**Optional `## Size Waiver Rationale` section** (issue #27): if you know
+this iter's diff will exceed the 3× magnitude threshold for intentional
+reasons (e.g. the spec merged two former checkpoints, or scope was
+deliberately expanded with operator approval), include this section in
+output-summary.md. Required content: actual vs threshold overage,
+why it's intentional (cite spec line or operator decision), and
+confirmation that no off-scope files were introduced. The Evaluator
+reads this during the goal-relevance audit and — if all changed file
+groups also map to spec scope — emits `verdict: PASS` with
+`magnitude_advisory: true` instead of the usual REVIEW. Omitting this
+section on an oversized diff keeps the Evaluator on the REVIEW path.
+
 ## Boundaries
 
 **Will:**

--- a/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md
@@ -454,12 +454,24 @@ generator_completed_at: <ISO-8601 timestamp when this iter's commits landed>
 ---
 ```
 
-Sections: What Was Done (+ rationale), Files Modified, Git Commits (SHAs + messages), Rule Conflict Notes (empty if none), Notes for Evaluator.
+Sections: What Was Done (+ rationale), Files Modified, Git Commits (SHAs + messages), Rule Conflict Notes (empty if none), Notes for Evaluator. Optional: `## Size Waiver Rationale` (see below).
 
 The five `generator_*` fields are optional. The engine ignores them;
 existing summaries without them remain valid. See
 `docs/adr/0005-record-generator-and-planner-host-model.md` for the
 rationale.
+
+**Optional `## Size Waiver Rationale` section** (issue #27): when the
+Generator knows in advance that the checkpoint diff will exceed the
+3× magnitude threshold for intentional reasons (e.g. spec merged two
+former checkpoints, or scope was deliberately expanded with operator
+approval), include this section in output-summary.md. The Evaluator
+reads it during the goal-relevance audit and — if all changed file
+groups also map to spec scope — emits `verdict: PASS` with
+`magnitude_advisory: true` instead of REVIEW. Missing rationale on an
+oversized diff stays REVIEW. Required content: the actual vs threshold
+overage, why it's intentional (cite spec line or operator decision),
+and confirmation that no off-scope files were introduced.
 
 ---
 
@@ -478,16 +490,24 @@ evaluator_session_id: <session id from evaluator agent>
 # generator_model and planner_model. Engine ignores; older evaluations
 # without it remain valid.
 evaluator_model: <e.g., claude-opus-4-7, gpt-5.5>
+# Optional magnitude advisory (see issue #27). Set to true when verdict is
+# PASS but the magnitude check was exceeded AND the goal-relevance audit
+# passed AND a Size Waiver Rationale was present in output-summary.md.
+# Engine ignores; the field is informational so retro/review can see that
+# an overrun was reviewed and accepted rather than missed.
+magnitude_advisory: true | false
 ---
 ```
 
 The `verdict` frontmatter is parsed by `$ENGINE pass-checkpoint`. It must match the Verdict section. A checkpoint cannot pass unless the latest iteration's `evaluation.md` has `verdict: PASS`, and the same iteration contains `evaluator-session-id.txt` with a session id that was not used by any prior checkpoint.
 
+When `magnitude_advisory: true`, evaluation.md MUST also contain a `## Magnitude Advisory` section recording: actual insertions vs threshold, actual file count vs threshold, the goal-relevance audit result (every file group's spec mapping), and the Size Waiver Rationale text from output-summary.md. This makes the overrun-accepted decision auditable in retro without having to cross-reference output-summary.md.
+
 ### Tier 1: Deterministic Checks (MANDATORY)
 
 Each section has: ran, passed/results, errors/failures, **evidence** (path in evidence/).
 
-- **Magnitude Check**: Read `effort_estimate` from context.md frontmatter. Compute actual insertions (`git diff --stat baseline_sha..HEAD | tail -1`) and file count (`git diff --name-only baseline_sha..HEAD | wc -l`). Compare against thresholds: S=50/3, M=150/8, L=300/12 files. If actual exceeds 3× estimate on either dimension → trigger REVIEW with focus on goal relevance. Evidence: actual vs expected numbers.
+- **Magnitude Check**: Read `effort_estimate` from context.md frontmatter. Compute actual insertions (`git diff --stat baseline_sha..HEAD | tail -1`) and file count (`git diff --name-only baseline_sha..HEAD | wc -l`). Compare against thresholds: S=50/3, M=150/8, L=300/12 files. If actual exceeds 3× estimate on either dimension → run goal-relevance audit. **Outcome A** (every file group maps to spec AND output-summary.md contains a `## Size Waiver Rationale`): emit `verdict: PASS` with `magnitude_advisory: true` in frontmatter plus a `## Magnitude Advisory` section in evaluation.md (actual vs threshold + audit result + waiver text). **Outcome B** (off-scope files OR no waiver rationale): trigger REVIEW with goal-relevance focus. Issue #27. Evidence: actual vs expected numbers in both outcomes.
 - **Tests**: ran, passed (N/total), failed_tests, evidence
 - **Test Coverage** (backend/infrastructure/fullstack ONLY, plus any frontend checkpoint whose spec explicitly requires coverage): ran, coverage_percent (project-wide or checkpoint-scoped as specified), threshold (from `.harness/config.json` `coverage_threshold`, default 85, or stricter spec value), passed (coverage ≥ threshold), evidence. **FAIL if required coverage is unmeasured or below threshold** — hard gate. Measured using the project's configured coverage tool. Skip for `Type: frontend` checkpoints only when the spec does not require frontend coverage.
 - **TDD Commit Sequence** (backend/infrastructure/fullstack ONLY): verified (Red commit with failing tests exists before Green commit with passing implementation), evidence (commit SHAs showing test-first order). Skip for `Type: frontend` checkpoints.


### PR DESCRIPTION
## Summary

When a checkpoint's diff exceeds the 3× magnitude threshold for **intentional** reasons (spec merged two former checkpoints, scope deliberately expanded with operator approval), the Evaluator can now emit `verdict: PASS` with a `magnitude_advisory: true` annotation instead of forcing REVIEW.

Two-gate contract:

1. **Goal-relevance audit must pass** — every changed file group maps to spec scope. Off-scope files keep REVIEW.
2. **Output-summary.md must contain `## Size Waiver Rationale`** — the Generator declares the intentional overrun, cites the spec line or operator decision, and confirms no off-scope files. Missing rationale keeps REVIEW.

Pure docs/contract change. **No engine code change** — `pass-checkpoint` already accepts `verdict: PASS` unconditionally; the advisory annotation is informational, recorded for retro/review auditability so an operator can see the overrun was reviewed and accepted rather than missed.

## Why

Reported in issue #27 from ContentGenerator task `cg-personal-launch CP06`:

- Baseline → head diff: 2,624 insertions / 37 files
- M 3× threshold: 450 insertions / 24 files
- Goal-relevance audit: every file mapped to CP06 spec
- CP06 spec explicitly merged former CP06 + CP07 per evaluator guidance

The Evaluator correctly performed the audit and saw the scope was intentional, but the existing rule forced REVIEW anyway → blocked `pass-checkpoint` despite a clean evaluation. The advisory annotation closes this false-blocker class.

## Scope

| File | Change |
|---|---|
| `plugins/harness-engineering-skills/agents/harness-evaluator.md` | Key Action 3: two-outcome branch (Outcome A → PASS + advisory; Outcome B → REVIEW) |
| `plugins/harness-engineering-skills/agents/harness-generator.md` | Outputs section: declares the optional `## Size Waiver Rationale` section contract |
| `plugins/harness-engineering-skills/skills/harness/references/protocol-quick-ref.md` | evaluation.md schema (new `magnitude_advisory` field + mandatory `## Magnitude Advisory` section); output-summary.md schema (Size Waiver Rationale); Tier 1 Magnitude Check description |

## Coexists with `pre-classified-review-pattern`

The existing pre-classified pattern (`protocol-quick-ref.md` §pre-classified-review-pattern) still emits REVIEW for Orchestrator auto-resolution on **scaffold checkpoints with deterministic commands**. The new advisory pattern bypasses REVIEW entirely when both gates pass and is intended for **evaluator-validated intentional scope expansion** in non-scaffold work. Different surfaces; clear separation.

## Test plan

- [x] All existing tests pass (`test-spec-evaluator-parallel-group.sh`, `check-parallel-cohort-rules.sh`, `test-engine-coverage-gate.sh`, `test-preflight-scoped-staging.sh`, `test-claude-artifact-frontmatter.sh`, `test-claude-agent-invoke-e2e.sh`).
- [ ] CodeRabbit / codex-connector review.

## Out of scope

- Fixture spec test that asserts an Evaluator agent emits PASS + magnitude_advisory under the right conditions — depends on extending the Evaluator runtime parser; should land alongside the next parser-extension PR.
- Engine validation that `magnitude_advisory: true` is only emitted when conditions are met — the rule is cybernetic (Evaluator self-enforces); discoverable in retro/review if violated. Adding engine validation would add complexity without changing the contract.

## Rollback plan

`git revert <merge-sha>` — pure prose addition. No engine code, no script behavior change, no data migration. Existing evaluations without `magnitude_advisory` remain valid (field is optional).