### PR TITLE
feat(harness): Codex Generator defaults to sub-agent dispatch (#34)

### DIFF
--- a/plugins/harness-engineering-skills/skills/harness/SKILL.md
+++ b/plugins/harness-engineering-skills/skills/harness/SKILL.md
@@ -87,13 +87,13 @@ Orchestrator (you, the Main Agent — Claude Code or Codex)
 │   ├── harness-convention-scout → sub-agent, host-repo convention discovery + Card
 │   ↕ spec-review/     → iterate with Spec Evaluator on checkpoint quality
 ├── Spec Evaluator     → sub-agent, architecture + feasibility
-├── Generator          → sub-agent (or local in Codex), TDD skill preloaded
+├── Generator          → sub-agent (Claude or Codex), TDD skill preloaded
 │   ↕ evaluation       → iterate with Evaluator per checkpoint
 ├── Evaluator          → sub-agent, composite sensor
 └── Retro              → sub-agent, produces retro.md
 ```
 
-**Sub-agent dispatch:** In Claude Code use `Agent(subagent_type: "harness-*", prompt: <context>)`. In Codex use `claude-agent-invoke.sh` to dispatch via CLI. See [references/codex-mode.md](references/codex-mode.md) for Codex-specific details.
+**Sub-agent dispatch:** In Claude Code use `Agent(subagent_type: "harness-*", prompt: <context>)`. In Codex, use `claude-agent-invoke.sh` for reviewer agents (Spec Evaluator, Evaluator, Convention Scout, Retro); for the Generator role, dispatch a fresh Codex sub-process via the `peer-invoke.sh`-style pattern documented in [references/codex-mode.md](references/codex-mode.md) §Execution. Main-session local implementation is the fallback path, not the default — see codex-mode.md for the fallback contract and `HARNESS_GENERATOR_MODE` status marker.
 
 **Anti-drift mechanisms:**
 - Fresh Generator + Evaluator per checkpoint (full eigenbehavior reset)

--- a/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
+++ b/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md
@@ -34,29 +34,47 @@ CLAUDE_AGENT="$HARNESS_DIR/scripts/claude-agent-invoke.sh"
 
 ## Sub-agent Mode Expectations
 
-At the start of any `harness continue` run, the Codex host emits an
-early-run status marker naming the execution mode:
+At the start of any `harness continue` run, the Codex host emits early-run
+status markers for both the reviewer-agent path and the Generator path:
 
 ```text
 HARNESS_SUBAGENT_MODE=subagents
+HARNESS_GENERATOR_MODE=subagent
 ```
 
-or:
+If either path falls back to main-session execution, emit the corresponding
+fallback marker:
 
 ```text
 HARNESS_SUBAGENT_MODE=main-session-fallback
+HARNESS_GENERATOR_MODE=main-session-fallback
 ```
 
-The explicit fallback rule is: when a required sub-agent dispatch path is
-available (`claude-agent-invoke.sh` plus the target agent definition), use it;
-when it is missing, unavailable, or returns a tooling/runtime error before the
-agent can produce the required artifact, stop at the relevant protocol gate and
-record `main-session-fallback` rather than silently self-evaluating. Source:
-issue #14.
+The explicit fallback rules:
 
-Main-session fallback may continue only for Generator work that the Codex host
-is already allowed to perform locally. It must not write evaluator-owned
-artifacts such as `evaluation.md`, `e2e-report.md`, or retro outputs.
+- **Reviewer agents** (Spec Evaluator, Convention Scout, Evaluator, Retro) —
+  when `claude-agent-invoke.sh` plus the target agent definition are available,
+  use them. When missing, unavailable, or returning a tooling/runtime error
+  before the agent can produce the required artifact, stop at the relevant
+  protocol gate and record `HARNESS_SUBAGENT_MODE=main-session-fallback`
+  rather than silently self-evaluating. Source: issue #14.
+- **Generator** (per-checkpoint implementation) — when the Codex sub-agent
+  dispatch mechanism is available (e.g. `peer-invoke.sh --peer codex`, a
+  `codex-agent-invoke.sh` wrapper if installed, or `codex exec` from an
+  isolated `CODEX_HOME`), use it. When unavailable OR when the user has
+  explicitly opted into local implementation (e.g. via a `--generator-mode local`
+  override or a `local_generator: true` `.harness/config.json` entry), the
+  Orchestrator MAY implement locally — and MUST record
+  `HARNESS_GENERATOR_MODE=main-session-fallback` in the run's early marker
+  and in each checkpoint's `status.md` (`generator_mode: main-session-fallback`)
+  so the loss of context isolation is auditable. Source: issue #34.
+
+Reviewer-agent fallback may NOT write evaluator-owned artifacts
+(`evaluation.md`, `e2e-report.md`, retro outputs) under any circumstance —
+those gates remain hard. Generator fallback may write `output-summary.md`
+and implementation commits because the Orchestrator is itself a Generator-
+capable role; the marker exists so retro can see when context isolation was
+lost.
 
 ## Planning in Codex
 
@@ -98,8 +116,36 @@ For each checkpoint:
 
 1. `"$ENGINE" begin-checkpoint ...`
 2. `"$ENGINE" assemble-context ...`
-3. Codex implements the checkpoint locally in the current session.
-   - Do not require Codex subagents. Use them only if the user explicitly asked for delegation.
+3. **Generator dispatch — sub-agent is the default.** Spawn a fresh Codex
+   sub-process to play the Generator role for this checkpoint so the
+   Orchestrator context stays clean across the run. The sub-process reads
+   the same anti-drift envelope the Claude path uses (`context.md`, the
+   checkpoint's scope/acceptance/files-of-interest, the relevant
+   protocol-quick-ref sections) and writes the same output contract:
+   - **Output**: implementation commits on the current branch, plus
+     `.harness/<task>/checkpoints/<NN>/iter-<N>/output-summary.md` per
+     `protocol-quick-ref.md` § output-summary.md.
+   - **Session proof**: record the Codex sub-process session id to
+     `.harness/<task>/checkpoints/<NN>/iter-<N>/generator-session-id.txt`
+     so retro can confirm a fresh Generator per checkpoint.
+   - **Retry path**: on Evaluator FAIL or auto-resolvable REVIEW, the
+     Orchestrator increments the iter counter, re-dispatches a fresh
+     Generator sub-process with the prior `evaluation.md` feedback
+     injected into the prompt, and lets the new sub-process commit the
+     fix. Do NOT re-use the prior Generator session across iterations.
+   - **Dispatch mechanism**: use `peer-invoke.sh --peer codex
+     --prompt-file <generator-prompt> --output-file
+     <generator-raw-output> --session-id-file <generator-session-file>`
+     for environments where the review-loop skill is installed; a future
+     `codex-agent-invoke.sh` will provide the symmetric wrapper to
+     `claude-agent-invoke.sh`.
+   - **Fallback**: if sub-process dispatch is unavailable OR the operator
+     has opted into local implementation, the Orchestrator MAY implement
+     locally. Record `HARNESS_GENERATOR_MODE=main-session-fallback` in
+     the run marker AND `generator_mode: main-session-fallback` in the
+     checkpoint's `status.md` so the loss of context isolation is
+     visible. Issue #34.
+
 4. After each implementation iteration, invoke Claude for checkpoint evaluation:
 
 ```bash

--- a/scripts/test-codex-mode-generator-default.sh
+++ b/scripts/test-codex-mode-generator-default.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Doc-drift detector for issue #34: codex-mode.md and SKILL.md must agree
+# that the Generator role runs in a fresh sub-agent (Claude OR Codex) per
+# checkpoint, with local main-session execution as the explicit fallback
+# (not the default). Catches future regressions where a doc edit silently
+# re-introduces "Codex implements the checkpoint locally" as the default
+# Generator path.
+#
+# This is a small, focused assertion set — it does not parse markdown or
+# attempt full semantic understanding. It looks for the specific phrases
+# that encode the contract.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+codex_mode="$repo_root/plugins/harness-engineering-skills/skills/harness/references/codex-mode.md"
+skill="$repo_root/plugins/harness-engineering-skills/skills/harness/SKILL.md"
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" "$file" || {
+    echo "codex-mode/SKILL drift: $file is missing expected text: $needle" >&2
+    exit 1
+  }
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq -- "$needle" "$file"; then
+    echo "codex-mode/SKILL drift: $file contains forbidden text: $needle" >&2
+    echo "(Removed by issue #34. If you really need to re-introduce, update this test too.)" >&2
+    exit 1
+  fi
+}
+
+# ── codex-mode.md asserts ──
+
+# Generator sub-agent default is documented as the primary path.
+assert_contains "$codex_mode" "Generator dispatch — sub-agent is the default"
+
+# Fallback path is documented with the marker.
+assert_contains "$codex_mode" "HARNESS_GENERATOR_MODE=subagent"
+assert_contains "$codex_mode" "HARNESS_GENERATOR_MODE=main-session-fallback"
+assert_contains "$codex_mode" "generator-session-id.txt"
+
+# The pre-#34 phrasing that established "local by default" is gone.
+assert_not_contains "$codex_mode" "Codex implements the checkpoint locally in the current session."
+assert_not_contains "$codex_mode" "Do not require Codex subagents. Use them only if the user explicitly asked for delegation."
+
+# ── SKILL.md asserts ──
+
+# Architecture line treats Generator as a sub-agent role for both hosts.
+assert_contains "$skill" "Generator          → sub-agent (Claude or Codex)"
+
+# Anti-drift "fresh Generator + Evaluator per checkpoint" is preserved.
+assert_contains "$skill" "Fresh Generator + Evaluator per checkpoint"
+
+# The pre-#34 phrasing "(or local in Codex)" is gone — would re-introduce
+# the contradiction between SKILL.md's anti-drift line and codex-mode.md.
+assert_not_contains "$skill" "(or local in Codex)"
+
+echo "codex-mode + SKILL generator-default consistency test passed"


### PR DESCRIPTION
## Summary

Resolve the contradiction between SKILL.md's anti-drift line ("Fresh Generator + Evaluator per checkpoint") and codex-mode.md's previous default ("Codex implements the checkpoint locally... Do not require Codex subagents"). Closes #34.

Codex-hosted Generator dispatch is now sub-agent by default, with main-session execution as the explicit, marked fallback — same shape as the existing reviewer-agent fallback rule from issue #14.

## Contract

- **Default**: spawn a fresh Codex sub-process per checkpoint. Reads `context.md` + scope + quick-ref; writes `output-summary.md` + implementation commits; records `generator-session-id.txt` for retro confirmation that each checkpoint got a fresh Generator.
- **Retry path**: on FAIL or auto-resolvable REVIEW, increment iter and re-dispatch a fresh sub-process with the prior `evaluation.md` injected. Never reuse the Generator session across iters.
- **Fallback**: when dispatch is unavailable OR the user explicitly opts into local mode, the Orchestrator MAY implement locally — and MUST record `HARNESS_GENERATOR_MODE=main-session-fallback` in the run marker AND `generator_mode: main-session-fallback` in each checkpoint's `status.md` so loss of context isolation is auditable.

## Acceptance criteria from #34

- [x] `references/codex-mode.md` no longer states Codex implements each checkpoint locally by default.
- [x] Protocol defines a Codex-hosted Generator sub-agent path with prompt inputs, output contract (`output-summary.md` + commits), retry path, and session-id proof.
- [x] Main-session fallback is explicit, degraded, and marker-recorded (parallel to reviewer-agent fallback rule).
- [x] SKILL.md architecture diagram and codex-mode.md are consistent — "fresh Generator + Evaluator per checkpoint" applies to both Claude and Codex hosts.
- [x] Doc-drift regression test (`scripts/test-codex-mode-generator-default.sh`) asserts the new contract phrases appear in both docs and forbids re-introduction of the pre-#34 "local in current session" / "(or local in Codex)" wording.

## What this PR does NOT do

- It does not ship `codex-agent-invoke.sh` (the script wrapper symmetric to `claude-agent-invoke.sh`). The protocol contract is defined; the wrapper script is a follow-up. Operators can use the existing `peer-invoke.sh --peer codex` in the review-loop skill for Codex sub-process dispatch today — it already supports prompt injection, output capture, session-id recording, and timeout handling.
- It does not change `harness-engine.sh` behavior. The engine continues to read `evaluation.md` verdicts as before; the new `generator_mode` field in `status.md` is informational only.

## Test plan

- [x] `bash scripts/test-codex-mode-generator-default.sh` — new drift detector passes.
- [x] `bash scripts/test-spec-evaluator-parallel-group.sh` — passes.
- [x] `bash scripts/check-parallel-cohort-rules.sh` — passes.
- [x] `bash scripts/test-engine-coverage-gate.sh` — passes (10/10 scenarios).
- [x] `bash scripts/test-preflight-scoped-staging.sh` — passes.
- [x] `bash scripts/test-claude-artifact-frontmatter.sh` — passes.
- [x] `bash scripts/test-claude-agent-invoke-e2e.sh` — passes.

## Rollback plan

`git revert <merge-sha>` — pure docs + one new test script. No engine code change, no script behavior change, no data migration. The `status.md` `generator_mode` field is optional and ignored by the engine.