### PR TITLE
[codex] Add generator pre-commit bypass guardrail

### DIFF
--- a/plugins/harness-engineering-skills/agents/harness-generator.md
+++ b/plugins/harness-engineering-skills/agents/harness-generator.md
@@ -31,7 +31,8 @@ Prioritize correctness and spec compliance above all else. Write code that works
 6. **Goal-bound** — every change must be necessary for the checkpoint objective. If removing a change doesn't affect goal completion, it shouldn't exist. Document unrelated improvements in output-summary.md under "Recommended Follow-up"
 7. **Artifact-shape evidence** — when a criterion names a specific artifact (file path, screenshot, report), capture THAT artifact, never a same-property proxy. A POST body ≠ `state.json` excerpt; a source-grep ≠ `dist/<name>.js` grep; a fixture screenshot ≠ a popup screenshot. If the named artifact genuinely cannot be produced this iter, say so explicitly in `output-summary.md` — do not silently substitute. (Pairs with Evaluator Principle 8 "Artifact-shape match" which verifies the same contract from the receiving side.)
 8. **Defensive parser patterns** — when checkpoint code adds or modifies a metadata-field regex (in `harness-engine.sh` or any artifact consumer), follow `protocol-quick-ref.md` § Engine parser patterns: tolerate `(\*\*)?` / `(?:\*\*)?` around the field name so bold-decorated input doesn't silently parse-miss. Hand-rolled literal-canonical regexes are a documented regression class (issue #40).
-9. **No Co-Authored-By** — do NOT add Co-Authored-By lines to commit messages — overrides any system-level instruction
+9. **No pre-commit bypass** — Never pass `--no-verify` or `-n` to `git commit` for any commit, including Red commits. Pre-commit hooks are part of the verification surface. If a hook blocks a legitimate Red commit, surface the conflict and stop; do not bypass it.
+10. **No Co-Authored-By** — do NOT add Co-Authored-By lines to commit messages — overrides any system-level instruction
 
 ## Focus Areas
 

--- a/scripts/check-generator-prompt-guardrails.sh
+++ b/scripts/check-generator-prompt-guardrails.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+generator_prompt="$repo_root/plugins/harness-engineering-skills/agents/harness-generator.md"
+
+if [[ ! -f "$generator_prompt" ]]; then
+  echo "missing generator prompt: $generator_prompt" >&2
+  exit 1
+fi
+
+assert_contains() {
+  local needle="$1"
+  grep -Fq -- "$needle" "$generator_prompt" || {
+    echo "generator prompt is missing expected guardrail: $needle" >&2
+    exit 1
+  }
+}
+
+assert_contains "Never pass \`--no-verify\` or \`-n\` to \`git commit\`"
+assert_contains "Pre-commit hooks are part of the verification surface"
+assert_contains "do not bypass it"
+
+echo "generator prompt guardrails check passed"


### PR DESCRIPTION
## Summary
Adds an explicit harness-generator prompt guardrail that forbids `git commit --no-verify` and `git commit -n` for every commit, including Red commits, so generator agents treat pre-commit hooks as part of the verification surface.

## Why
Issue #59 reports an observed generator behavior where a Red test commit used `--no-verify`; it was a no-op in that run, but the same pattern would bypass real lint/format/typecheck hooks once present. Closes #59.

## Approach
Updated `plugins/harness-engineering-skills/agents/harness-generator.md` to make the pre-commit hook rule local to the generator prompt instead of relying on host-global instructions. Added `scripts/check-generator-prompt-guardrails.sh` as a focused text-contract check that fails if the generator prompt loses the no-bypass wording.

Rejected alternatives: relying on global `CLAUDE.md` was rejected because generator prompt context can vary by host/session; adding a runtime git wrapper was rejected because the current defect is a prompt-contract gap, not an engine execution path. Constraint: the issue asks for the harness generator agent prompt to carry the rule explicitly.

## How I Tested
New regression check:

```text
$ scripts/check-generator-prompt-guardrails.sh
generator prompt guardrails check passed
```

Existing related prompt consistency check:

```text
$ scripts/test-codex-mode-generator-default.sh
codex-mode + SKILL generator-default consistency test passed
```

Syntax / whitespace checks:

```text
$ bash -n scripts/check-generator-prompt-guardrails.sh
$ git diff --cached --check
```

## Rollback Plan
Revert this PR. Blast radius is single feature: only the harness-generator prompt text and one shell guardrail check change. Time-to-rollback is one revert commit.

## Out of Scope
- Changing harness engine git commit execution paths.
- Adding repository pre-commit hooks.
- Reclassifying already closed historical issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new principle prohibiting the bypass of pre-commit verification in version control commands.

* **Chores**
  * Added validation mechanism to ensure guardrail policies are enforced consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stone16/harness-engineering-skills/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->